### PR TITLE
Feature add notebook test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,29 @@
-.PHONY: format lint
+.PHONY: format lint dev-lint
 
 GIT_ROOT ?= $(shell git rev-parse --show-toplevel)
 
 format:
 	black .
 
+dev-lint:
+	mypy .
+	black .
+	ruff check . --fix
+
 lint:
 	mypy .
 	black . --check
 	ruff check .
 
+
 test:
 	pytest tests
+
+unit-test:
+	pytest tests/unit
+
+integration-test:
+	pytest tests/integration
+
+notebook-test:
+	pytest tests/notebook

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,4 +6,7 @@ mypy==1.5.1
 ruff==0.0.285
 
 # Test
+ipykernel==6.24.0
+nbconvert==7.6.0
+nbformat==5.9.1
 pytest==7.4.0

--- a/tests/notebook/test_notebooks.py
+++ b/tests/notebook/test_notebooks.py
@@ -1,0 +1,27 @@
+import unittest
+import os
+import nbformat
+from nbconvert.preprocessors import ExecutePreprocessor
+
+
+class TestNotebooks(unittest.TestCase):
+    def _test_notebook(self, filepath: str, timeout: int = 30):
+        module_path = os.path.dirname(__file__)
+        file_path = os.path.join(module_path, "..", "..", "docs", "source", filepath)
+        with open(file_path) as f:
+            nb = nbformat.read(f, as_version=4)
+            ep = ExecutePreprocessor(timeout=timeout)
+            ep.preprocess(nb)
+
+    def test_first_example(self):
+        self._test_notebook("getting_started/first_example.ipynb", timeout=10)
+
+    @unittest.skip("indexing takes too long")
+    def test_llamaindex(self):
+        self._test_notebook("examples/integrations/llamaindex_integration.ipynb")
+
+    def test_langchain_llm(self):
+        self._test_notebook("examples/integrations/langchain_llm_integration.ipynb")
+
+    def test_multi_chain_agent(self):
+        self._test_notebook("examples/multi_chain_agent.ipynb", timeout=60)


### PR DESCRIPTION
- Add a test runner for notebooks
- Add convenience target to Makefile:
  - `dev-lint` to lint with auto fix enabled
  - test targets: `unit-test`, `integration-test`, `notebook-test`