### PR TITLE
Add parameters to google skills init

### DIFF
--- a/council/skills/google/google_news_skill.py
+++ b/council/skills/google/google_news_skill.py
@@ -11,14 +11,14 @@ class GoogleNewsSkill(SkillBase):
 
     """
 
-    def __init__(self, suffix: str = ""):
+    def __init__(self, period="90d", nb_results=5, suffix: str = ""):
         super().__init__("gnews")
-        self.gn = GoogleNewsSearchEngine(period="90d", suffix=suffix)
+        self.gn = GoogleNewsSearchEngine(period=period, suffix=suffix)
+        self.nb_results = nb_results
 
     def execute(self, context: SkillContext) -> ChatMessage:
         prompt = context.chat_history.try_last_user_message.unwrap("no user message")
-
-        resp = self.gn.execute(query=prompt.message, nb_results=5)
+        resp = self.gn.execute(query=prompt.message, nb_results=self.nb_results)
         response_count = len(resp)
         if response_count > 0:
             return self.build_success_message(

--- a/council/skills/google/google_news_skill.py
+++ b/council/skills/google/google_news_skill.py
@@ -1,3 +1,6 @@
+from typing import Optional
+from datetime import datetime
+
 import json
 
 from council.contexts import ChatMessage, SkillContext
@@ -11,9 +14,16 @@ class GoogleNewsSkill(SkillBase):
 
     """
 
-    def __init__(self, period="90d", nb_results=5, suffix: str = ""):
+    def __init__(
+        self,
+        suffix: str = "",
+        nb_results=5,
+        period: Optional[str] = "90d",
+        start: Optional[datetime] = None,
+        end: Optional[datetime] = None,
+    ):
         super().__init__("gnews")
-        self.gn = GoogleNewsSearchEngine(period=period, suffix=suffix)
+        self.gn = GoogleNewsSearchEngine(period=period, suffix=suffix, start=start, end=end)
         self.nb_results = nb_results
 
     def execute(self, context: SkillContext) -> ChatMessage:

--- a/council/skills/google/google_search_skill.py
+++ b/council/skills/google/google_search_skill.py
@@ -15,13 +15,14 @@ class GoogleSearchSkill(SkillBase):
 
     """
 
-    def __init__(self):
+    def __init__(self, nb_results=5):
         super().__init__("gsearch")
         self.gs = GoogleSearchEngine.from_env()
+        self.nb_results = nb_results
 
     def execute(self, context: SkillContext) -> ChatMessage:
         prompt = context.chat_history.try_last_user_message.unwrap("no user message")
-        resp = self.gs.execute(query=prompt.message, nb_results=5)
+        resp = self.gs.execute(query=prompt.message, nb_results=self.nb_results)
         response_count = len(resp)
         if response_count > 0:
             return self.build_success_message(

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ anthropic>=0.5.0
 # Skills
 ## Google
 google-api-python-client==2.106.0
-GoogleNews==1.6.10
+GoogleNews>=1.6.10
 google-api-python-client-stubs==1.18.0
 pymediawiki~=0.7.3
 beautifulsoup4~=4.12.2

--- a/tests/integration/skills/test_google_skills.py
+++ b/tests/integration/skills/test_google_skills.py
@@ -42,7 +42,7 @@ class TestBase(unittest.TestCase):
 
     def test_gsearch_skill(self):
         context = ChainContext.from_user_message("USD", budget=Budget(duration=10))
-        
+
         skill = GoogleSearchSkill()
         result = skill.execute(SkillContext.from_chain_context(context, Option.none()))
         self.assertTrue(result.is_ok)

--- a/tests/integration/skills/test_google_skills.py
+++ b/tests/integration/skills/test_google_skills.py
@@ -44,6 +44,29 @@ class TestBase(unittest.TestCase):
             self.assertEqual(len(d["snippet"]), 0)
             self.assertTrue(is_within_period(d["date"], 15))
 
+    def test_gnews_skill_range(self):
+        context = ChainContext.from_user_message("launch of Space Shuttle Endeavour", Budget(duration=10))
+        context.chat_history.add_user_message("STS-134")
+
+        expected_result_count = 4
+        skill = GoogleNewsSkill(
+            suffix="Space",
+            nb_results=expected_result_count,
+            period=None,
+            start=datetime(2011, 5, 1),
+            end=datetime(2011, 5, 30),
+        )
+        result = skill.execute(SkillContext.from_chain_context(context, Option.none()))
+        self.assertTrue(result.is_ok)
+
+        json_loads = json.loads(result.data)
+        self.assertLessEqual(expected_result_count, len(json_loads))
+        for d in json_loads:
+            self.assertGreater(len(d["title"]), 0)
+            self.assertGreater(len(d["url"]), 0)
+            self.assertEqual(len(d["snippet"]), 0)
+            # self.assertTrue(is_within_period(d["date"], 15))
+
     def test_gsearch_skill(self):
         context = ChainContext.from_user_message("USD", budget=Budget(duration=10))
 

--- a/tests/integration/skills/test_google_skills.py
+++ b/tests/integration/skills/test_google_skills.py
@@ -45,7 +45,7 @@ class TestBase(unittest.TestCase):
             self.assertTrue(is_within_period(d["date"], 15))
 
     def test_gnews_skill_range(self):
-        context = ChainContext.from_user_message("launch of Space Shuttle Endeavour", Budget(duration=10))
+        context = ChainContext.from_user_message("last launch of Space Shuttle Endeavour", Budget(duration=10))
         context.chat_history.add_user_message("STS-134")
 
         expected_result_count = 4
@@ -65,7 +65,6 @@ class TestBase(unittest.TestCase):
             self.assertGreater(len(d["title"]), 0)
             self.assertGreater(len(d["url"]), 0)
             self.assertEqual(len(d["snippet"]), 0)
-            # self.assertTrue(is_within_period(d["date"], 15))
 
     def test_gsearch_skill(self):
         context = ChainContext.from_user_message("USD", budget=Budget(duration=10))

--- a/tests/integration/skills/test_google_skills.py
+++ b/tests/integration/skills/test_google_skills.py
@@ -42,12 +42,11 @@ class TestBase(unittest.TestCase):
 
     def test_gsearch_skill(self):
         context = ChainContext.from_user_message("USD", budget=Budget(duration=10))
-
+        
         skill = GoogleSearchSkill()
         result = skill.execute(SkillContext.from_chain_context(context, Option.none()))
         self.assertTrue(result.is_ok)
         self.assertIn("USD", result.message)
-        print(result.data)
         for d in json.loads(result.data):
             self.assertGreater(len(d["title"]), 0)
             self.assertGreater(len(d["url"]), 0)

--- a/tests/integration/skills/test_google_skills.py
+++ b/tests/integration/skills/test_google_skills.py
@@ -2,6 +2,8 @@ import unittest
 
 import dotenv
 
+import json
+
 from council.contexts import ChainContext, Budget, ChatHistory, SkillContext
 from council.skills.google import GoogleNewsSkill, GoogleSearchSkill
 from council.skills.google.google_context import GoogleNewsSearchEngine, GoogleSearchEngine
@@ -32,6 +34,11 @@ class TestBase(unittest.TestCase):
         result = skill.execute(SkillContext.from_chain_context(context, Option.none()))
         self.assertTrue(result.is_ok)
         self.assertIn("EUR", result.message)
+        for d in json.loads(result.data):
+            self.assertGreater(len(d["title"]), 0)
+            self.assertGreater(len(d["url"]), 0)
+            self.assertEqual(len(d["snippet"]), 0)
+            self.assertIsNotNone(d["date"])
 
     def test_gsearch_skill(self):
         context = ChainContext.from_user_message("USD", budget=Budget(duration=10))
@@ -40,6 +47,12 @@ class TestBase(unittest.TestCase):
         result = skill.execute(SkillContext.from_chain_context(context, Option.none()))
         self.assertTrue(result.is_ok)
         self.assertIn("USD", result.message)
+        print(result.data)
+        for d in json.loads(result.data):
+            self.assertGreater(len(d["title"]), 0)
+            self.assertGreater(len(d["url"]), 0)
+            self.assertGreater(len(d["snippet"]), 0)
+            self.assertIsNone(d["date"])
 
     def test_skill_no_message(self):
         context = ChainContext.from_chat_history(ChatHistory(), Budget(duration=10))

--- a/tests/integration/skills/test_google_skills.py
+++ b/tests/integration/skills/test_google_skills.py
@@ -16,13 +16,13 @@ class TestBase(unittest.TestCase):
         expected = 8
         gn = GoogleNewsSearchEngine(period="90d", suffix="Finance")
         resp = gn.execute(query="USD", nb_results=expected)
-        self.assertEquals(len(resp), expected)
+        self.assertEqual(len(resp), expected)
 
     def test_gsearch(self):
         expected = 8
         gn = GoogleSearchEngine.from_env()
         resp = gn.execute(query="USD", nb_results=expected)
-        self.assertEquals(len(resp), expected)
+        self.assertEqual(len(resp), expected)
 
     def test_gnews_skill(self):
         context = ChainContext.from_user_message("USD", Budget(duration=10))

--- a/tests/integration/skills/test_google_skills.py
+++ b/tests/integration/skills/test_google_skills.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime, timedelta
 
 import dotenv
 
@@ -14,13 +15,13 @@ class TestBase(unittest.TestCase):
     def setUp(self) -> None:
         dotenv.load_dotenv()
 
-    def test_gnews(self):
+    def test_gnews_engine(self):
         expected = 8
         gn = GoogleNewsSearchEngine(period="90d", suffix="Finance")
         resp = gn.execute(query="USD", nb_results=expected)
         self.assertEqual(len(resp), expected)
 
-    def test_gsearch(self):
+    def test_gsearch_engine(self):
         expected = 8
         gn = GoogleSearchEngine.from_env()
         resp = gn.execute(query="USD", nb_results=expected)
@@ -30,24 +31,32 @@ class TestBase(unittest.TestCase):
         context = ChainContext.from_user_message("USD", Budget(duration=10))
         context.chat_history.add_user_message("EUR")
 
-        skill = GoogleNewsSkill(suffix="Finance")
+        expected_result_count = 4
+        skill = GoogleNewsSkill(suffix="Finance", nb_results=expected_result_count, period="15d")
         result = skill.execute(SkillContext.from_chain_context(context, Option.none()))
         self.assertTrue(result.is_ok)
-        self.assertIn("EUR", result.message)
-        for d in json.loads(result.data):
+
+        json_loads = json.loads(result.data)
+        self.assertLessEqual(expected_result_count, len(json_loads))
+        for d in json_loads:
             self.assertGreater(len(d["title"]), 0)
             self.assertGreater(len(d["url"]), 0)
             self.assertEqual(len(d["snippet"]), 0)
-            self.assertIsNotNone(d["date"])
+            self.assertTrue(is_within_period(d["date"], 15))
 
     def test_gsearch_skill(self):
         context = ChainContext.from_user_message("USD", budget=Budget(duration=10))
 
-        skill = GoogleSearchSkill()
+        expected_result_count = 7
+        skill = GoogleSearchSkill(nb_results=expected_result_count)
         result = skill.execute(SkillContext.from_chain_context(context, Option.none()))
+
         self.assertTrue(result.is_ok)
         self.assertIn("USD", result.message)
-        for d in json.loads(result.data):
+
+        json_loads = json.loads(result.data)
+        self.assertEqual(expected_result_count, len(json_loads))
+        for d in json_loads:
             self.assertGreater(len(d["title"]), 0)
             self.assertGreater(len(d["url"]), 0)
             self.assertGreater(len(d["snippet"]), 0)
@@ -61,3 +70,30 @@ class TestBase(unittest.TestCase):
             self.assertTrue(False)
         except OptionException as oe:
             self.assertTrue(oe)
+
+
+def parse_relative_timestamp(timestamp: str) -> datetime:
+    if "minute" in timestamp:
+        minutes_ago = int(timestamp.split()[0])
+        return datetime.now() - timedelta(minutes=minutes_ago)
+    if "hour" in timestamp:
+        hours_ago = int(timestamp.split()[0])
+        return datetime.now() - timedelta(hours=hours_ago)
+    if "day" in timestamp:
+        days_ago = int(timestamp.split()[0])
+        return datetime.now() - timedelta(days=days_ago)
+    if "week" in timestamp:
+        weeks_ago = int(timestamp.split()[0])
+        return datetime.now() - timedelta(weeks=weeks_ago)
+    else:
+        raise ValueError("Unsupported relative timestamp format")
+
+
+def is_within_period(result: str, period: int) -> bool:
+    if "ago" in result:
+        publication_date = parse_relative_timestamp(result)
+    else:
+        publication_date = datetime.strptime(result, "%Y-%m-%d")
+
+    delta = datetime.now() - publication_date
+    return delta <= timedelta(days=period)


### PR DESCRIPTION
1. Added `nb_results` for `GoogleSearchSkill` initialization
2. Added `nb_results`, `start`-`end` range, and `period` for `GoogleNewsSearchSkill` initialization
3. Update integration test cases to include assertions of fields in the json search results