### PR TITLE
Support custom OpenAI api hosts

### DIFF
--- a/council/llm/openai_llm.py
+++ b/council/llm/openai_llm.py
@@ -4,7 +4,12 @@ from typing import Any, Optional
 import httpx
 from httpx import TimeoutException, HTTPStatusError
 
-from . import OpenAIChatCompletionsModel, OpenAITokenCounter, LLMCallTimeoutException, LLMCallException
+from . import (
+    OpenAIChatCompletionsModel,
+    OpenAITokenCounter,
+    LLMCallTimeoutException,
+    LLMCallException,
+)
 from .llm_config_object import LLMConfigObject, LLMProviders
 from .openai_llm_configuration import OpenAILLMConfiguration
 
@@ -21,7 +26,10 @@ class OpenAIChatCompletionsModelProvider:
         self._name = name
 
     def post_request(self, payload: dict[str, Any]) -> httpx.Response:
-        uri = "https://api.openai.com/v1/chat/completions"
+        """
+        Posts a request to the OpenAI chat completions endpoint.
+        """
+        uri = self.config.api_host.unwrap() + "/v1/chat/completions"
 
         timeout = self.config.timeout.unwrap()
         try:
@@ -48,8 +56,8 @@ class OpenAILLM(OpenAIChatCompletionsModel):
         )
 
     @staticmethod
-    def from_env(model: Optional[str] = None) -> OpenAILLM:
-        config: OpenAILLMConfiguration = OpenAILLMConfiguration.from_env(model=model)
+    def from_env(model: Optional[str] = None, api_host: Optional[str] = None) -> OpenAILLM:
+        config: OpenAILLMConfiguration = OpenAILLMConfiguration.from_env(model=model, api_host=api_host)
         return OpenAILLM(config)
 
     @staticmethod

--- a/council/llm/openai_llm_configuration.py
+++ b/council/llm/openai_llm_configuration.py
@@ -3,7 +3,13 @@ from typing import Any, Optional
 
 from council.llm import LLMConfigurationBase
 from council.llm.llm_config_object import LLMConfigSpec
-from council.utils import read_env_str, read_env_int, Parameter, greater_than_validator, prefix_validator
+from council.utils import (
+    read_env_str,
+    read_env_int,
+    Parameter,
+    greater_than_validator,
+    prefix_validator,
+)
 from council.llm.llm_configuration_base import _DEFAULT_TIMEOUT
 
 _env_var_prefix = "OPENAI_"
@@ -17,11 +23,12 @@ class OpenAILLMConfiguration(LLMConfigurationBase):
         * see https://platform.openai.com/docs/api-reference/chat
     """
 
-    def __init__(self, api_key: str, model: str, timeout: int = _DEFAULT_TIMEOUT):
+    def __init__(self, api_key: str, api_host: str, model: str, timeout: int = _DEFAULT_TIMEOUT):
         """
         Initialize a new instance of OpenAILLMConfiguration
         Args:
             api_key (str): the OpenAI api key
+            api_host (str): the OpenAI Host
             model (str): model version to use
             timeout (int): seconds to wait for response from OpenAI before timing out
         """
@@ -32,6 +39,13 @@ class OpenAILLMConfiguration(LLMConfigurationBase):
         )
         self._api_key = Parameter.string(
             name="api_key", required=True, value=api_key, validator=prefix_validator("sk-")
+        )
+        self._api_host = Parameter.string(
+            name="api_host",
+            required=False,
+            value=api_host,
+            default="https://api.openai.com",
+            validator=None,
         )
 
     @property
@@ -49,6 +63,13 @@ class OpenAILLMConfiguration(LLMConfigurationBase):
         return self._api_key
 
     @property
+    def api_host(self) -> Parameter[str]:
+        """
+        OpenAI API Host
+        """
+        return self._api_host
+
+    @property
     def timeout(self) -> Parameter[int]:
         """
         API timeout
@@ -62,22 +83,29 @@ class OpenAILLMConfiguration(LLMConfigurationBase):
         return payload
 
     @staticmethod
-    def from_env(model: Optional[str] = None) -> OpenAILLMConfiguration:
+    def from_env(model: Optional[str] = None, api_host: Optional[str] = None) -> OpenAILLMConfiguration:
         api_key = read_env_str(_env_var_prefix + "API_KEY").unwrap()
+        if api_host is None:
+            api_host = read_env_str(
+                _env_var_prefix + "API_HOST", required=False, default="https://api.openai.com"
+            ).unwrap()
+
         if model is None:
             model = read_env_str(_env_var_prefix + "LLM_MODEL", required=False, default="gpt-3.5-turbo").unwrap()
+
         timeout = read_env_int(_env_var_prefix + "LLM_TIMEOUT", required=False, default=_DEFAULT_TIMEOUT).unwrap()
 
-        config = OpenAILLMConfiguration(model=model, api_key=api_key, timeout=timeout)
+        config = OpenAILLMConfiguration(model=model, api_key=api_key, api_host=api_host, timeout=timeout)
         config.read_env(_env_var_prefix)
         return config
 
     @staticmethod
     def from_spec(spec: LLMConfigSpec) -> OpenAILLMConfiguration:
         api_key: str = spec.provider.must_get_value("apiKey")
+        api_host: Any = spec.provider.get_value("apiHost")
         model: str = spec.provider.must_get_value("model")
 
-        config = OpenAILLMConfiguration(api_key=api_key, model=str(model))
+        config = OpenAILLMConfiguration(api_key=api_key, api_host=api_host, model=str(model))
         if spec.parameters is not None:
             config.from_dict(spec.parameters)
 

--- a/council/llm/openai_llm_configuration.py
+++ b/council/llm/openai_llm_configuration.py
@@ -8,7 +8,7 @@ from council.utils import (
     read_env_int,
     Parameter,
     greater_than_validator,
-    not_empty_validator,
+    prefix_validator,
 )
 from council.llm.llm_configuration_base import _DEFAULT_TIMEOUT
 
@@ -33,12 +33,12 @@ class OpenAILLMConfiguration(LLMConfigurationBase):
             timeout (int): seconds to wait for response from OpenAI before timing out
         """
         super().__init__()
-        self._model = Parameter.string(name="model", required=True, value=model, validator=not_empty_validator(model))
+        self._model = Parameter.string(name="model", required=True, value=model, validator=prefix_validator("gpt-"))
         self._timeout = Parameter.int(
             name="timeout", required=False, default=timeout, validator=greater_than_validator(0)
         )
         self._api_key = Parameter.string(
-            name="api_key", required=True, value=api_key, validator=not_empty_validator(api_key)
+            name="api_key", required=True, value=api_key, validator=prefix_validator("sk-")
         )
 
         self._api_host = Parameter.string(
@@ -46,7 +46,7 @@ class OpenAILLMConfiguration(LLMConfigurationBase):
             required=False,
             value=api_host,
             default="https://api.openai.com",
-            validator=None,
+            validator=prefix_validator("http"),
         )
 
     @property
@@ -103,7 +103,7 @@ class OpenAILLMConfiguration(LLMConfigurationBase):
     @staticmethod
     def from_spec(spec: LLMConfigSpec) -> OpenAILLMConfiguration:
         api_key: str = spec.provider.must_get_value("apiKey")
-        api_host: Any = spec.provider.get_value("apiHost")
+        api_host: str = spec.provider.get_value("apiHost") or "https://api.openai.com"
         model: str = spec.provider.must_get_value("model")
 
         config = OpenAILLMConfiguration(api_key=api_key, api_host=api_host, model=str(model))

--- a/council/llm/openai_llm_configuration.py
+++ b/council/llm/openai_llm_configuration.py
@@ -8,7 +8,7 @@ from council.utils import (
     read_env_int,
     Parameter,
     greater_than_validator,
-    prefix_validator,
+    not_empty_validator,
 )
 from council.llm.llm_configuration_base import _DEFAULT_TIMEOUT
 
@@ -33,13 +33,14 @@ class OpenAILLMConfiguration(LLMConfigurationBase):
             timeout (int): seconds to wait for response from OpenAI before timing out
         """
         super().__init__()
-        self._model = Parameter.string(name="model", required=True, value=model, validator=prefix_validator("gpt-"))
+        self._model = Parameter.string(name="model", required=True, value=model, validator=not_empty_validator(model))
         self._timeout = Parameter.int(
             name="timeout", required=False, default=timeout, validator=greater_than_validator(0)
         )
         self._api_key = Parameter.string(
-            name="api_key", required=True, value=api_key, validator=prefix_validator("sk-")
+            name="api_key", required=True, value=api_key, validator=not_empty_validator(api_key)
         )
+
         self._api_host = Parameter.string(
             name="api_host",
             required=False,

--- a/council/utils/parameter.py
+++ b/council/utils/parameter.py
@@ -138,6 +138,16 @@ class Parameter(Generic[T]):
         default = f" Default value `{self._default}`." if not isinstance(self._default, Undefined) else ""
         return f"Parameter{opt} `{self._name}` with {val}.{default}"
 
+    def __eq__(self, other: Any) -> bool:
+        if self.is_none():
+            if isinstance(other, Parameter):
+                return other.is_none()
+            return False
+
+        if isinstance(other, Parameter):
+            return self.unwrap() == other.unwrap()
+        return self.unwrap() == other
+
     @staticmethod
     def string(
         name: str,

--- a/council/utils/parameter.py
+++ b/council/utils/parameter.py
@@ -75,15 +75,16 @@ class Parameter(Generic[T]):
         self._name = name
         self._required = required
         self._validator: Validator = validator if validator is not None else lambda x: None
+        self._default = default
         if isinstance(value, Undefined):
-            self._value: Option[T] = Option.none()
+            if not isinstance(default, Undefined):
+                self.set(default)
+            else:
+                self._value: Option[T] = Option.none()
         else:
             self.set(value)
 
         self._read_env = converter
-        self._default = default
-        if not isinstance(default, Undefined):
-            self.set(default)
 
     def from_env(self, env_var: str):
         v = self._read_env(env_var, self._required)
@@ -144,7 +145,12 @@ class Parameter(Generic[T]):
         validator: Optional[Validator] = None,
     ) -> "Parameter[str]":
         return Parameter(
-            name=name, required=required, value=value, converter=read_env_str, default=default, validator=validator
+            name=name,
+            required=required,
+            value=value,
+            converter=read_env_str,
+            default=default,
+            validator=validator,
         )
 
     @staticmethod
@@ -156,7 +162,12 @@ class Parameter(Generic[T]):
         validator: Optional[Validator] = None,
     ) -> "Parameter[int]":
         return Parameter(
-            name=name, required=required, value=value, converter=read_env_int, default=default, validator=validator
+            name=name,
+            required=required,
+            value=value,
+            converter=read_env_int,
+            default=default,
+            validator=validator,
         )
 
     @staticmethod
@@ -168,5 +179,10 @@ class Parameter(Generic[T]):
         validator: Optional[Validator] = None,
     ) -> "Parameter[float]":
         return Parameter(
-            name=name, required=required, value=value, converter=read_env_float, default=default, validator=validator
+            name=name,
+            required=required,
+            value=value,
+            converter=read_env_float,
+            default=default,
+            validator=validator,
         )

--- a/tests/data/openai-llmodel.yaml
+++ b/tests/data/openai-llmodel.yaml
@@ -13,6 +13,8 @@ spec:
       timeout: 60
       apiKey:
         fromEnvVar: OPENAI_API_KEY
+      apiHost:
+        fromEnvVar: OPENAI_API_HOST
   parameters:
     n: 3
     temperature: 0.5

--- a/tests/unit/llm/test_llm_config_object.py
+++ b/tests/unit/llm/test_llm_config_object.py
@@ -1,5 +1,5 @@
 from council import OpenAILLM, AzureLLM, AnthropicLLM
-from council.llm import get_llm_from_config, LLMFallback
+from council.llm import get_llm_from_config, LLMFallback, OpenAILLMConfiguration
 from council.llm.llm_config_object import LLMConfigObject
 from council.utils import OsEnviron
 
@@ -9,14 +9,18 @@ from .. import get_data_filename, LLModels
 def test_openai_from_yaml():
     filename = get_data_filename(LLModels.OpenAI)
 
-    with OsEnviron("OPENAI_API_KEY", "sk-key"):
+    with OsEnviron("OPENAI_API_KEY", "sk-key"), OsEnviron("OPENAI_API_HOST", "https://openai.com"):
         actual = LLMConfigObject.from_yaml(filename)
         assert actual.spec.provider.name == "CML-OpenAI"
 
         llm = OpenAILLM.from_config(actual)
         assert isinstance(llm, OpenAILLM)
-        assert llm.config.temperature.value == 0.5
-        assert llm.config.n.value == 3
+
+        assert isinstance(llm.config, OpenAILLMConfiguration)
+        config: OpenAILLMConfiguration = llm.config
+        assert config.temperature == 0.5
+        assert config.n == 3
+        assert config.api_host == "https://openai.com"
 
         llm = get_llm_from_config(filename)
         assert isinstance(llm, OpenAILLM)

--- a/tests/unit/llm/test_openai_llm_configuration.py
+++ b/tests/unit/llm/test_openai_llm_configuration.py
@@ -17,7 +17,7 @@ class TestOpenAILLMConfiguration(unittest.TestCase):
             self.assertEqual("gpt-not-default", config.model.value)
 
     def test_default(self):
-        config = OpenAILLMConfiguration(model="gpt-model", api_key="sk-key")
+        config = OpenAILLMConfiguration(model="gpt-model", api_key="sk-key", api_host="https://api.openai.com")
         self.assertEqual(0.0, config.temperature.value)
         self.assertEqual(1, config.n.value)
         self.assertTrue(config.top_p.is_none())
@@ -26,6 +26,8 @@ class TestOpenAILLMConfiguration(unittest.TestCase):
 
     def test_invalid(self):
         with self.assertRaises(ParameterValueException):
-            _ = OpenAILLMConfiguration(model="a-gpt-model", api_key="sk-key")
+            _ = OpenAILLMConfiguration(model="a-gpt-model", api_key="sk-key", api_host="https://api.openai.com")
         with self.assertRaises(ParameterValueException):
-            _ = OpenAILLMConfiguration(model="gpt-model", api_key="a-sk-key")
+            _ = OpenAILLMConfiguration(model="gpt-model", api_key="a-sk-key", api_host="https://api.openai.com")
+        with self.assertRaises(ParameterValueException):
+            _ = OpenAILLMConfiguration(model="gpt-model", api_key="sk-key", api_host="api.openai.com")

--- a/tests/unit/utils/test_parameter.py
+++ b/tests/unit/utils/test_parameter.py
@@ -1,7 +1,7 @@
 import unittest
 
 from council.utils import MissingEnvVariableException, EnvVariableValueException, OsEnviron
-from council.utils.parameter import ParameterValueException, Parameter
+from council.utils.parameter import ParameterValueException, Parameter, Undefined
 
 
 def tv(x: float):
@@ -68,3 +68,15 @@ class TestParameter(unittest.TestCase):
         with OsEnviron("TEST_LLM_TEMPERATURE", "9876.54321"):
             temperature.from_env("TEST_LLM_TEMPERATURE")
         self.assertEqual(temperature.unwrap(), 9876.54321)
+
+    def test_equal(self) -> None:
+        temperature1: Parameter[float] = Parameter.float(name="temperature1", required=False, value=12.34)
+        temperature2: Parameter[float] = Parameter.float(name="temperature2", required=True, value=12.34)
+        temperature3: Parameter[float] = Parameter.float(name="temperature3", required=True, value=43.21)
+
+        self.assertTrue(temperature1 == temperature2)
+        self.assertTrue(temperature1 == 12.34)
+
+        self.assertFalse(temperature1 == temperature3)
+        self.assertFalse(temperature1 == 43.21)
+        self.assertFalse(temperature1 == Undefined())


### PR DESCRIPTION
This adds support for custom API hosts for the OpenAI LLM. Needed to run against custom inference end points with OpenAI API compatibility.

- Add api_host parameter to support custom OpenAI API host
- Fix an issue where default values for config parameters would override the specified value
- Update docstrings for clarity and documentation purposes
- Adjust imports to multiple lines for readability
