### PR TITLE
Feature CodeParser no regex

### DIFF
--- a/council/utils/code_parser.py
+++ b/council/utils/code_parser.py
@@ -25,6 +25,8 @@ class CodeBlock:
 
 
 class CodeParser:
+    DELIMITER = "```"
+
     @staticmethod
     def iter_code_blocs(language: Optional[str] = None, text: str = "") -> Iterable[CodeBlock]:
         return CodeParser._build_generator(language, text)
@@ -45,21 +47,26 @@ class CodeParser:
 
     @staticmethod
     def _build_generator(language: Optional[str], text: str = "") -> Iterable[CodeBlock]:
-        delimiter = "```"
-        actual_language: Optional[str] = None
-        code_lines: Optional[List[str]] = None
-        for line in text.split("\n"):
-            if line.startswith(delimiter) and code_lines is None:
-                actual_language = line[3:]
-                code_lines = []
+        lines = text.split("\n")
+        i = 0
+
+        while i < len(lines):
+            if not lines[i].startswith(CodeParser.DELIMITER):
+                i += 1
                 continue
 
-            if line == delimiter:
-                if (actual_language == language or language is None) and code_lines is not None:
-                    yield CodeBlock(language, "\n".join(code_lines))
-                code_lines = None
-                actual_language = None
-                continue
+            # start of a code block found
+            actual_block_language = lines[i][len(CodeParser.DELIMITER) :].strip() or None
+            start_index = i + 1
+            i += 1
 
-            if code_lines is not None:
-                code_lines.append(line)
+            while i < len(lines) and lines[i] != CodeParser.DELIMITER:
+                i += 1
+
+            if i >= len(lines):
+                break  # incomplete block
+
+            if actual_block_language == language or language is None:
+                yield CodeBlock(actual_block_language, "\n".join(lines[start_index:i]))
+
+            i += 1  # skip the closing delimiter

--- a/tests/unit/utils/test_code_parser.py
+++ b/tests/unit/utils/test_code_parser.py
@@ -41,6 +41,13 @@ class TestCodeParser(unittest.TestCase):
             "```",
         ]
 
+        self._nested = [
+            "```python",
+            "print('```csv')",
+            "print(df.to_csv(index=False))" "print('```')",
+            "```",
+        ]
+
         self._cpp = ["```c++", "int main() {", "    return 0;", "}", "```"]
 
         self._message = "\n".join(
@@ -60,6 +67,8 @@ class TestCodeParser(unittest.TestCase):
         self._message_empty_no_whitespace = "\n".join(
             ["Here is an empty code block with no whitespace:"] + self._empty_no_whitespace
         )
+
+        self._message_with_nested_block = "\n".join(["Here is code block that contains ``` inside"] + self._nested)
 
     def test_parse_all_python(self):
         code_blocks = CodeParser.extract_code_blocs(language="python", text=self._message)
@@ -96,6 +105,10 @@ class TestCodeParser(unittest.TestCase):
     def test_empty_code_block_no_whitespace(self):
         code_block = CodeParser.find_first(language="python", text=self._message_empty_no_whitespace)
         self.assertEqual(code_block.code, "")
+
+    def test_nested(self):
+        code_block = CodeParser.find_first(language="python", text=self._message_with_nested_block)
+        self.assertEqual("\n".join(self._nested[1:-1]), code_block.code)
 
     def test_cpp(self):
         code_block = CodeParser.find_first(language="c++", text=self._message)

--- a/tests/unit/utils/test_code_parser.py
+++ b/tests/unit/utils/test_code_parser.py
@@ -30,17 +30,6 @@ class TestCodeParser(unittest.TestCase):
             "```",
         ]
 
-        self._empty_with_whitespace = [
-            "```python",
-            "",
-            "```",
-        ]
-
-        self._empty_no_whitespace = [
-            "```python",
-            "```",
-        ]
-
         self._nested = [
             "```python",
             "print('```csv')",
@@ -61,14 +50,49 @@ class TestCodeParser(unittest.TestCase):
         )
 
         self._message_empty_with_whitespace = "\n".join(
-            ["Here is an empty code block with whitespace:"] + self._empty_with_whitespace
+            [
+                "Here is an empty code block with whitespace:",
+                "```python",
+                "",
+                "```",
+            ]
         )
 
         self._message_empty_no_whitespace = "\n".join(
-            ["Here is an empty code block with no whitespace:"] + self._empty_no_whitespace
+            [
+                "Here is an empty code block with no whitespace:",
+                "```python",
+                "```",
+            ]
         )
 
         self._message_with_nested_block = "\n".join(["Here is code block that contains ``` inside"] + self._nested)
+
+        self._message_incomplete = "\n".join(
+            [
+                "Here is an incomplete code block:",
+                "```",
+                "This block has no closing delimiter",
+            ]
+        )
+
+        self._message_incomplete_python = "\n".join(
+            [
+                "Here is an incomplete python code block:",
+                "```python",
+                "def incomplete_function():",
+                "    print('This block has no closing delimiter')",
+            ]
+        )
+
+        self._message_whitespace_after_delimiter = "\n".join(
+            [
+                "Here is a block with whitespace after delimiter:",
+                "```python    ",
+                "print('Whitespace after delimiter')",
+                "```",
+            ]
+        )
 
     def test_parse_all_python(self):
         code_blocks = CodeParser.extract_code_blocs(language="python", text=self._message)
@@ -98,6 +122,11 @@ class TestCodeParser(unittest.TestCase):
         self.assertIsNotNone(code_block)
         self.assertEqual("\n".join(self._python2[1:-1]), code_block.code)
 
+    def test_find_last_yaml(self):
+        code_block = CodeParser.find_last(language="yaml", text=self._message)
+        self.assertIsNotNone(code_block)
+        self.assertEqual("\n".join(self._yaml[1:-1]), code_block.code)
+
     def test_empty_code_block_with_whitespace(self):
         code_block = CodeParser.find_first(language="python", text=self._message_empty_with_whitespace)
         self.assertEqual(code_block.code, "")
@@ -109,6 +138,19 @@ class TestCodeParser(unittest.TestCase):
     def test_nested(self):
         code_block = CodeParser.find_first(language="python", text=self._message_with_nested_block)
         self.assertEqual("\n".join(self._nested[1:-1]), code_block.code)
+
+    def test_incomplete_block(self):
+        code_blocks = list(CodeParser.extract_code_blocs(text=self._message_incomplete))
+        self.assertEqual(len(code_blocks), 0)
+
+    def test_incomplete_block_python(self):
+        code_blocks = list(CodeParser.extract_code_blocs(language="python", text=self._message_incomplete_python))
+        self.assertEqual(len(code_blocks), 0)
+
+    def test_whitespace_after_delimiter(self):
+        code_block = CodeParser.find_first(language="python", text=self._message_whitespace_after_delimiter)
+        self.assertIsNotNone(code_block)
+        self.assertEqual(code_block.code, "print('Whitespace after delimiter')")
 
     def test_cpp(self):
         code_block = CodeParser.find_first(language="c++", text=self._message)

--- a/tests/unit/utils/test_code_parser.py
+++ b/tests/unit/utils/test_code_parser.py
@@ -33,7 +33,8 @@ class TestCodeParser(unittest.TestCase):
         self._nested = [
             "```python",
             "print('```csv')",
-            "print(df.to_csv(index=False))" "print('```')",
+            "print(df.to_csv(index=False))",
+            "print('```')",
             "```",
         ]
 


### PR DESCRIPTION
- Implement `CodeParser` with string match instead of regex
- Add more tests, including having ``` inside a code block