### PR TITLE
Feature refactor consumption calculators

### DIFF
--- a/council/llm/__init__.py
+++ b/council/llm/__init__.py
@@ -9,7 +9,14 @@ from .llm_answer import llm_property, LLMAnswer, LLMProperty, LLMParsingExceptio
 from .llm_exception import LLMException, LLMCallException, LLMCallTimeoutException, LLMTokenLimitException
 from .llm_message import LLMMessageRole, LLMMessage, LLMMessageTokenCounterBase
 from .llm_base import LLMBase, LLMResult, LLMConfigurationBase
-from .llm_cost import LLMCostCard, LLMConsumptionCalculatorBase, TokenKind, LLMCostManagerSpec, LLMCostManagerObject
+from .llm_cost import (
+    LLMCostCard,
+    LLMConsumptionCalculatorBase,
+    DefaultLLMConsumptionCalculator,
+    TokenKind,
+    LLMCostManagerSpec,
+    LLMCostManagerObject,
+)
 from .llm_fallback import LLMFallback
 from .llm_middleware import (
     LLMRequest,

--- a/council/llm/gemini_llm.py
+++ b/council/llm/gemini_llm.py
@@ -5,10 +5,10 @@ from typing import Any, List, Mapping, Optional, Sequence, Tuple
 import google.generativeai as genai  # type: ignore
 from council.contexts import Consumption, LLMContext
 from council.llm import (
+    DefaultLLMConsumptionCalculator,
     GeminiLLMConfiguration,
     LLMBase,
     LLMConfigObject,
-    LLMConsumptionCalculatorBase,
     LLMCostCard,
     LLMCostManagerObject,
     LLMMessage,
@@ -22,7 +22,7 @@ from google.ai.generativelanguage_v1 import HarmCategory  # type: ignore
 from google.generativeai.types import GenerateContentResponse, HarmBlockThreshold  # type: ignore
 
 
-class GeminiConsumptionCalculator(LLMConsumptionCalculatorBase):
+class GeminiConsumptionCalculator(DefaultLLMConsumptionCalculator):
     _cost_manager = LLMCostManagerObject.gemini()
     COSTS_UNDER_128k: Mapping[str, LLMCostCard] = _cost_manager.get_cost_map("under_128k")
     COSTS_OVER_128k: Mapping[str, LLMCostCard] = _cost_manager.get_cost_map("over_128k")

--- a/council/llm/openai_chat_completions_llm.py
+++ b/council/llm/openai_chat_completions_llm.py
@@ -142,18 +142,18 @@ class OpenAIConsumptionCalculator(LLMConsumptionCalculatorBase):
 
         return None
 
-    def get_openai_consumptions(self, duration: float, usage: Usage) -> List[Consumption]:
+    def get_consumptions(self, duration: float, usage: Usage) -> List[Consumption]:
         """
         Get consumptions specific for OpenAI:
             - 1 call
             - specified duration
             - cache_read_prompt, prompt, reasoning, completion and total tokens
-            - costs LLMCostCard can be found
+            - corresponding costs if LLMCostCard can be found
         """
-        consumptions = self.get_openai_base_consumptions(duration, usage) + self.get_openai_cost_consumptions(usage)
+        consumptions = self.get_base_consumptions(duration, usage) + self.get_cost_consumptions(usage)
         return self.filter_zeros(consumptions)  # could occur for cache/reasoning tokens
 
-    def get_openai_base_consumptions(self, duration: float, usage: Usage) -> List[Consumption]:
+    def get_base_consumptions(self, duration: float, usage: Usage) -> List[Consumption]:
         return [
             Consumption.call(1, self.model),
             Consumption.duration(duration, self.model),
@@ -164,7 +164,7 @@ class OpenAIConsumptionCalculator(LLMConsumptionCalculatorBase):
             Consumption.token(usage.total_tokens, self.format_kind(TokenKind.total)),
         ]
 
-    def get_openai_cost_consumptions(self, usage: Usage) -> List[Consumption]:
+    def get_cost_consumptions(self, usage: Usage) -> List[Consumption]:
         cost_card = self.find_model_costs()
         if cost_card is None:
             return []
@@ -226,7 +226,7 @@ class OpenAIChatCompletionsResult:
 
     def to_consumptions(self, duration: float) -> Sequence[Consumption]:
         consumption_calculator = OpenAIConsumptionCalculator(self.model)
-        return consumption_calculator.get_openai_consumptions(duration, self.usage)
+        return consumption_calculator.get_consumptions(duration, self.usage)
 
     @staticmethod
     def from_response(response: Dict[str, Any]) -> OpenAIChatCompletionsResult:

--- a/tests/integration/llm/test_gemini_llm.py
+++ b/tests/integration/llm/test_gemini_llm.py
@@ -66,3 +66,14 @@ class TestGeminiLLM(unittest.TestCase):
             action = LLMMessage.user_message("What is in the image?")
             result = instance.post_chat_request(LLMContext.empty(), [message, action])
             print(result.first_choice)
+
+    def test_consumptions(self):
+        messages = [LLMMessage.user_message("Hello how are you?")]
+        dotenv.load_dotenv()
+        with OsEnviron("GEMINI_LLM_MODEL", "gemini-1.5-flash-8b"):
+            instance = GeminiLLM.from_env()
+            result = instance.post_chat_request(LLMContext.empty(), messages)
+
+            assert len(result.consumptions) == 8  # call, duration, 3 token kinds and 3 cost kinds
+            for consumption in result.consumptions:
+                assert consumption.kind.startswith("gemini-1.5-flash-8b")

--- a/tests/integration/llm/test_openai_llm.py
+++ b/tests/integration/llm/test_openai_llm.py
@@ -62,3 +62,19 @@ class TestLlmOpenAI(unittest.TestCase):
         messages = [LLMMessage.user_message("Hello")]
         result = self.llm.post_chat_request(LLMContext.empty(), messages, model="o1-mini")
         print(result.first_choice)
+
+    def test_consumptions(self):
+        messages = [LLMMessage.user_message("Hello how are you?")]
+
+        result = self.llm.post_chat_request(LLMContext.empty(), messages, model="gpt-4o-mini")
+        assert len(result.consumptions) == 8  # call, duration, 3 token kinds and 3 cost kinds
+        for consumption in result.consumptions:
+            assert consumption.kind.startswith("gpt-4o-mini")
+
+    def test_o1_consumptions(self):
+        messages = [LLMMessage.user_message("Hello how are you?")]
+
+        result = self.llm.post_chat_request(LLMContext.empty(), messages, model="o1-mini")
+        assert len(result.consumptions) == 10  # call, duration, 3 token kinds + reasoning and 4 cost kinds
+        for consumption in result.consumptions:
+            assert consumption.kind.startswith("o1-mini")

--- a/tests/unit/llm/test_llm_consumption_calculators.py
+++ b/tests/unit/llm/test_llm_consumption_calculators.py
@@ -36,7 +36,7 @@ class TestAnthropicConsumptionCalculator(unittest.TestCase):
         self.assertEqual(completion_cost, 0.25)  # $5.00 * 0.05
 
     def test_haiku_3_cache_cost_calculation(self):
-        consumptions = AnthropicConsumptionCalculator("claude-3-haiku-20240307").get_anthropic_cost_consumptions(
+        consumptions = AnthropicConsumptionCalculator("claude-3-haiku-20240307").get_cost_consumptions(
             AnthropicUsage(
                 prompt_tokens=100_000,
                 completion_tokens=50_000,
@@ -52,7 +52,7 @@ class TestAnthropicConsumptionCalculator(unittest.TestCase):
         self.assertEqual(cache_read_cost.value, 0.015)  # $0.03 per 1M tokens * 0.5M tokens
 
     def test_haiku_35_cache_cost_calculation(self):
-        consumptions = AnthropicConsumptionCalculator("claude-3-5-haiku-20241022").get_anthropic_cost_consumptions(
+        consumptions = AnthropicConsumptionCalculator("claude-3-5-haiku-20241022").get_cost_consumptions(
             AnthropicUsage(
                 prompt_tokens=100_000,
                 completion_tokens=50_000,
@@ -85,7 +85,7 @@ class TestAnthropicConsumptionCalculator(unittest.TestCase):
         sonnet_versions = ["claude-3-5-sonnet-20240620", "claude-3-5-sonnet-20241022"]
 
         for version in sonnet_versions:
-            consumptions = AnthropicConsumptionCalculator(version).get_anthropic_cost_consumptions(
+            consumptions = AnthropicConsumptionCalculator(version).get_cost_consumptions(
                 AnthropicUsage(
                     prompt_tokens=100_000,
                     completion_tokens=50_000,
@@ -112,7 +112,7 @@ class TestAnthropicConsumptionCalculator(unittest.TestCase):
         self.assertEqual(completion_cost, 3.75)  # $75.00 * 0.05
 
     def test_opus_cache_cost_calculation(self):
-        consumptions = AnthropicConsumptionCalculator("claude-3-opus-20240229").get_anthropic_cost_consumptions(
+        consumptions = AnthropicConsumptionCalculator("claude-3-opus-20240229").get_cost_consumptions(
             AnthropicUsage(
                 prompt_tokens=100_000,
                 completion_tokens=50_000,
@@ -132,7 +132,7 @@ class TestAnthropicConsumptionCalculator(unittest.TestCase):
 
     def test_invalid_model_cache_costs(self):
         # doesn't support caching
-        consumptions = AnthropicConsumptionCalculator("claude-3-sonnet-20240229").get_anthropic_cost_consumptions(
+        consumptions = AnthropicConsumptionCalculator("claude-3-sonnet-20240229").get_cost_consumptions(
             AnthropicUsage(
                 prompt_tokens=100_000,
                 completion_tokens=50_000,
@@ -146,7 +146,11 @@ class TestAnthropicConsumptionCalculator(unittest.TestCase):
     def test_consumption_units_and_types(self):
         model = "claude-3-haiku-20240307"
         calculator = AnthropicConsumptionCalculator(model)
-        consumptions = calculator.get_cost_consumptions(prompt_tokens=1_000, completion_tokens=1_000)
+        consumptions = calculator.get_cost_consumptions(
+            AnthropicUsage(
+                prompt_tokens=1_000, completion_tokens=1_000, cache_creation_prompt_tokens=0, cache_read_prompt_tokens=0
+            )
+        )
 
         for consumption in consumptions:
             self.assertEqual(consumption.unit, "USD")
@@ -154,7 +158,7 @@ class TestAnthropicConsumptionCalculator(unittest.TestCase):
 
     def test_cache_consumption_units_and_types(self):
         model = "claude-3-5-sonnet-20241022"
-        consumptions = AnthropicConsumptionCalculator(model).get_anthropic_cost_consumptions(
+        consumptions = AnthropicConsumptionCalculator(model).get_cost_consumptions(
             AnthropicUsage(
                 prompt_tokens=100, completion_tokens=50, cache_creation_prompt_tokens=1000, cache_read_prompt_tokens=500
             )
@@ -303,7 +307,7 @@ class TestOpenAIConsumptionCalculator(unittest.TestCase):
             cached_tokens=1_000_000,
         )
 
-        consumptions = OpenAIConsumptionCalculator("gpt-4o").get_openai_cost_consumptions(usage)
+        consumptions = OpenAIConsumptionCalculator("gpt-4o").get_cost_consumptions(usage)
 
         cached_cost = next(c.value for c in consumptions if "cache_read_prompt_tokens_cost" in c.kind)
         prompt_cost = next(c.value for c in consumptions if "prompt_tokens_cost" in c.kind and "cache" not in c.kind)
@@ -323,7 +327,7 @@ class TestOpenAIConsumptionCalculator(unittest.TestCase):
             cached_tokens=0,
         )
 
-        consumptions = OpenAIConsumptionCalculator("o1-mini").get_openai_cost_consumptions(usage)
+        consumptions = OpenAIConsumptionCalculator("o1-mini").get_cost_consumptions(usage)
 
         reasoning_cost = next(c.value for c in consumptions if "reasoning_tokens_cost" in c.kind)
         completion_cost = next(c.value for c in consumptions if "completion_tokens_cost" in c.kind)


### PR DESCRIPTION
- Make `LLMConsumptionCalculatorBase.get_consumptions()` abstract to improve naming for child classes
- Introduce `DefaultLLMConsumptionCalculator` to be used for Gemini