### PR TITLE
Feature response parser to response template

### DIFF
--- a/council/llm/data/response_hints.yaml
+++ b/council/llm/data/response_hints.yaml
@@ -1,0 +1,22 @@
+# YAML
+yaml_hints_common: |
+  - Make sure you respect YAML syntax, particularly for lists and dictionaries.
+  - All keys must be present in the response, even when their values are empty.
+  - For empty values, include empty quotes ("") rather than leaving them blank.
+  - Always wrap string values in double quotes (") to ensure proper parsing, except when using the YAML pipe operator (|) for multi-line strings.
+yaml_parser_hints_start: |
+  - Provide your response as a parsable YAML.
+yaml_parser_hints_end: Only respond with parsable YAML. Do not output anything else. Do not wrap your response in ```yaml```.
+yaml_block_parser_hints_start: |
+  - Provide your response in a single yaml code block.
+
+# JSON
+json_hints_common: |
+  - Make sure you respect JSON syntax, particularly for lists and dictionaries.
+  - All keys must be present in the response, even when their values are empty.
+  - For empty values, include empty quotes ("") rather than leaving them blank.
+json_parser_hints_start: |
+  - Provide your response as a parsable JSON.
+json_parser_hints_end: Only respond with parsable JSON. Do not output anything else.
+json_block_parser_hints_start: |
+  - Provide your response in a single json code block.

--- a/council/llm/data/response_hints.yaml
+++ b/council/llm/data/response_hints.yaml
@@ -8,7 +8,7 @@ yaml_parser_hints_start: |
   - Provide your response as a parsable YAML.
 yaml_parser_hints_end: Only respond with parsable YAML. Do not output anything else. Do not wrap your response in ```yaml```.
 yaml_block_parser_hints_start: |
-  - Provide your response in a single yaml code block.
+  - Provide your response in a single YAML code block.
 
 # JSON
 json_hints_common: |
@@ -19,4 +19,4 @@ json_parser_hints_start: |
   - Provide your response as a parsable JSON.
 json_parser_hints_end: Only respond with parsable JSON. Do not output anything else.
 json_block_parser_hints_start: |
-  - Provide your response in a single json code block.
+  - Provide your response in a single JSON code block.

--- a/council/llm/llm_response_parser.py
+++ b/council/llm/llm_response_parser.py
@@ -185,7 +185,7 @@ class YAMLResponseParser(YAMLResponseParserBase):
         template_parts = [YAML_RESPONSE_PARSER_HINTS] if include_hints else []
         template_parts.append(cls._to_response_template())
         if include_hints:
-            template_parts.extend(["", "Only respond with parsable YAML. Do not output anything else."])
+            template_parts.extend(["", "Only respond with parsable YAML. Do not output anything else. Do not wrap your response in ```yaml```."])
         return "\n".join(template_parts)
 
 

--- a/council/llm/llm_response_parser.py
+++ b/council/llm/llm_response_parser.py
@@ -126,7 +126,7 @@ class YAMLResponseParserBase(BaseModelResponseParser, abc.ABC):
                 for line in description.split("\n"):
                     template_parts.append(f"  {line.strip()}")
             else:
-                template_parts.append(f"{field_name}: {{{{{description}}}}}")  # field_name: {{value}} when formatted
+                template_parts.append(f"{field_name}: # {description}")
 
         return "\n".join(template_parts)
 

--- a/council/llm/llm_response_parser.py
+++ b/council/llm/llm_response_parser.py
@@ -229,12 +229,10 @@ class JSONResponseParserBase(BaseModelResponseParser, abc.ABC):
             is_multiline = "\n" in description
 
             if field.annotation is str and is_multiline:
-                # For multiline strings, join the lines with newlines
                 template_dict[field_name] = "\n".join(line.strip() for line in description.split("\n"))
             else:
                 template_dict[field_name] = description
 
-        # Return formatted JSON with descriptions as values
         return json.dumps(template_dict, indent=2)
 
     @staticmethod

--- a/council/llm/llm_response_parser.py
+++ b/council/llm/llm_response_parser.py
@@ -1,9 +1,10 @@
+import abc
 import json
 import re
-from typing import Any, Callable, Dict, Type, TypeVar
+from typing import Any, Callable, Dict, Final, Type, TypeVar
 
 import yaml
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel, ConfigDict, ValidationError
 
 from ..utils import CodeParser
 from .llm_answer import LLMParsingException
@@ -30,10 +31,13 @@ class StringResponseParser:
         return response.value
 
 
-class BaseModelResponseParser(BaseModel):
+class BaseModelResponseParser(BaseModel, abc.ABC):
     """Base class for parsing LLM responses into structured data models"""
 
+    model_config = ConfigDict(frozen=True)  # to preserve field order
+
     @classmethod
+    @abc.abstractmethod
     def from_response(cls: Type[T], response: LLMResponse) -> T:
         """
         Parse an LLM response into a structured data model.
@@ -88,7 +92,53 @@ class CodeBlocksResponseParser(BaseModelResponseParser):
         return cls.create_and_validate(**parsed_blocks)
 
 
-class YAMLBlockResponseParser(BaseModelResponseParser):
+YAML_HINTS: Final[
+    str
+] = """
+- Make sure you respect YAML syntax, particularly for lists and dictionaries.
+- All keys must be present in the response, even when their values are empty.
+- For empty values, include empty quotes ("") rather than leaving them blank.
+- Always wrap string values in double quotes (") to ensure proper parsing, except when using the YAML pipe operator (|) for multi-line strings.
+"""
+
+YAML_RESPONSE_PARSER_HINTS: Final[str] = "- Provide your response as a parsable YAML." + YAML_HINTS
+
+YAML_BLOCK_RESPONSE_PARSER_HINTS: Final[str] = "- Provide your response in a single yaml code block." + YAML_HINTS
+
+T_YAMLResponseParserBase = TypeVar("T_YAMLResponseParserBase", bound="YAMLResponseParserBase")
+
+
+class YAMLResponseParserBase(BaseModelResponseParser, abc.ABC):
+    @classmethod
+    def _to_response_template(cls: Type[T]) -> str:
+        """Generate a YAML response template based on the model's fields and their descriptions."""
+        template_parts = []
+
+        for field_name, field in cls.model_fields.items():
+            description = field.description
+            if description is None:
+                raise ValueError(f"Description is required for field `{field_name}` in {cls.__name__}")
+
+            is_multiline = "\n" in description
+
+            if field.annotation is str and is_multiline:
+                template_parts.append(f"{field_name}: |")
+                for line in description.split("\n"):
+                    template_parts.append(f"  {line.strip()}")
+            else:
+                template_parts.append(f"{field_name}: {{{{{description}}}}}")  # field_name: {{value}} when formatted
+
+        return "\n".join(template_parts)
+
+    @staticmethod
+    def parse(content: str) -> Dict[str, Any]:
+        try:
+            return yaml.safe_load(content)
+        except yaml.YAMLError as e:
+            raise LLMParsingException(f"Error while parsing yaml: {e}")
+
+
+class YAMLBlockResponseParser(YAMLResponseParserBase):
 
     @classmethod
     def from_response(cls: Type[T], response: LLMResponse) -> T:
@@ -99,26 +149,45 @@ class YAMLBlockResponseParser(BaseModelResponseParser):
         if yaml_block is None:
             raise LLMParsingException("yaml block is not found")
 
-        yaml_content = YAMLResponseParser.parse(yaml_block.code)
+        yaml_content = YAMLResponseParserBase.parse(yaml_block.code)
         return cls.create_and_validate(**yaml_content)
 
+    @classmethod
+    def to_response_template(cls: Type[T_YAMLResponseParserBase], include_hints: bool = True) -> str:
+        """
+        Generate YAML block response template based on the model's fields and their descriptions.
 
-class YAMLResponseParser(BaseModelResponseParser):
+        Args:
+            include_hints: If True, returned template will include universal YAML block formatting hints.
+        """
+        template_parts = [YAML_BLOCK_RESPONSE_PARSER_HINTS] if include_hints else []
+        template_parts.extend(["```yaml", cls._to_response_template(), "```"])
+        return "\n".join(template_parts)
+
+
+class YAMLResponseParser(YAMLResponseParserBase):
 
     @classmethod
     def from_response(cls: Type[T], response: LLMResponse) -> T:
         """LLMFunction ResponseParser for response containing raw YAML content"""
         llm_response = response.value
 
-        yaml_content = YAMLResponseParser.parse(llm_response)
+        yaml_content = YAMLResponseParserBase.parse(llm_response)
         return cls.create_and_validate(**yaml_content)
 
-    @staticmethod
-    def parse(content: str) -> Dict[str, Any]:
-        try:
-            return yaml.safe_load(content)
-        except yaml.YAMLError as e:
-            raise LLMParsingException(f"Error while parsing yaml: {e}")
+    @classmethod
+    def to_response_template(cls: Type[T_YAMLResponseParserBase], include_hints: bool = True) -> str:
+        """
+        Generate YAML response template based on the model's fields and their descriptions.
+
+        Args:
+            include_hints: If True, returned template will include universal YAML formatting hints.
+        """
+        template_parts = [YAML_RESPONSE_PARSER_HINTS] if include_hints else []
+        template_parts.append(cls._to_response_template())
+        if include_hints:
+            template_parts.extend(["", "Only respond with parsable YAML. Do not output anything else."])
+        return "\n".join(template_parts)
 
 
 class JSONBlockResponseParser(BaseModelResponseParser):

--- a/docs/source/reference/llm/llm_response_parser.md
+++ b/docs/source/reference/llm/llm_response_parser.md
@@ -83,7 +83,7 @@ print(response.sql)
 import os
 from typing import Literal
 
-# !pip install council-ai==0.0.24
+# !pip install council-ai==0.0.27
 
 from council import OpenAILLM
 from council.llm.llm_function import LLMFunction
@@ -91,22 +91,19 @@ from council.llm.llm_response_parser import YAMLBlockResponseParser
 from pydantic import Field
 
 SYSTEM_PROMPT = """
-Output RPG character info in the following YAML block:
+Generate RPG character:
 
-```yaml
-character_class: # character's class (Warrior, Mage, Rogue, Bard or Tech Support)
-name: # character's name
-description: # character's tragic backstory, 50 chars minimum
-health: # character's health, integer, from 1 to 100 points
-```
+{response_template}
 """
 
 
 class RPGCharacterFromYAMLBlock(YAMLBlockResponseParser):
-    name: str
-    character_class: Literal["Warrior", "Mage", "Rogue", "Bard", "Tech Support"]
-    description: str = Field(..., min_length=50)
-    health: int = Field(..., ge=1, le=100)
+    character_class: Literal["Warrior", "Mage", "Rogue", "Bard", "Tech Support"] = Field(
+        ..., description="Character's class (Warrior, Mage, Rogue, Bard or Tech Support)"
+    )
+    name: str = Field(..., min_length=3, description="Character's name")
+    description: str = Field(..., min_length=50, description="Character's tragic backstory, 50 chars minimum")
+    health: int = Field(..., ge=1, le=100, description="Character's health, integer, from 1 to 100 points")
 
 
 os.environ["OPENAI_API_KEY"] = "sk-YOUR-KEY-HERE"
@@ -114,7 +111,9 @@ os.environ["OPENAI_LLM_MODEL"] = "gpt-4o-mini-2024-07-18"
 llm = OpenAILLM.from_env()
 
 llm_function: LLMFunction[RPGCharacterFromYAMLBlock] = LLMFunction(
-    llm, RPGCharacterFromYAMLBlock.from_response, SYSTEM_PROMPT
+    llm,
+    RPGCharacterFromYAMLBlock.from_response,
+    SYSTEM_PROMPT.format(response_template=RPGCharacterFromYAMLBlock.to_response_template()),
 )
 
 character = llm_function.execute(user_message="Create some wise mage")
@@ -155,7 +154,7 @@ Usage example with OpenAI json mode:
 import os
 from typing import Literal
 
-# !pip install council-ai==0.0.24
+# !pip install council-ai==0.0.27
 
 from council import OpenAILLM
 from council.llm.llm_function import LLMFunction
@@ -163,22 +162,19 @@ from council.llm.llm_response_parser import JSONResponseParser
 from pydantic import Field
 
 SYSTEM_PROMPT = """
-Output RPG character info in the following JSON format:
+Generate RPG character:
 
-{
-character_class: # character's class (Warrior, Mage, Rogue, Bard or Tech Support)
-name: # character's name
-description: # character's tragic backstory, 50 chars minimum
-health: # character's health, integer, from 1 to 100 points
-}
+{response_template}
 """
 
 
 class RPGCharacterFromJSON(JSONResponseParser):
-    name: str
-    character_class: Literal["Warrior", "Mage", "Rogue", "Bard", "Tech Support"]
-    description: str = Field(..., min_length=50)
-    health: int = Field(..., ge=1, le=100)
+    character_class: Literal["Warrior", "Mage", "Rogue", "Bard", "Tech Support"] = Field(
+        ..., description="Character's class (Warrior, Mage, Rogue, Bard or Tech Support)"
+    )
+    name: str = Field(..., min_length=3, description="Character's name")
+    description: str = Field(..., min_length=50, description="Character's tragic backstory, 50 chars minimum")
+    health: int = Field(..., ge=1, le=100, description="Character's health, integer, from 1 to 100 points")
 
 
 os.environ["OPENAI_API_KEY"] = "sk-YOUR-KEY-HERE"
@@ -186,11 +182,13 @@ os.environ["OPENAI_LLM_MODEL"] = "gpt-4o-mini-2024-07-18"
 llm = OpenAILLM.from_env()
 
 llm_function: LLMFunction[RPGCharacterFromJSON] = LLMFunction(
-    llm, RPGCharacterFromJSON.from_response, SYSTEM_PROMPT
+    llm,
+    RPGCharacterFromJSON.from_response,
+    SYSTEM_PROMPT.format(response_template=RPGCharacterFromJSON.to_response_template()),
 )
 
 character = llm_function.execute(
-    user_message="Create some wise mage",
+    user_message="Create some strong warrior",
     response_format={"type": "json_object"}  # using OpenAI's json mode
 )
 print(type(character))

--- a/tests/integration/llm/test_llm_response_parser_response_template.py
+++ b/tests/integration/llm/test_llm_response_parser_response_template.py
@@ -49,8 +49,6 @@ class JSONCharacter(JSONResponseParser, Character):
 
 
 class TestLLMResponseParserResponseTemplate(unittest.TestCase):
-    """Requires an Azure LLM model deployed"""
-
     def setUp(self) -> None:
         dotenv.load_dotenv()
         with OsEnviron("OPENAI_LLM_MODEL", "gpt-4o-mini"):

--- a/tests/integration/llm/test_llm_response_parser_response_template.py
+++ b/tests/integration/llm/test_llm_response_parser_response_template.py
@@ -25,7 +25,7 @@ Generate an RPG character.
 
 class Character:
     name: str = Field(..., description="The name of the character")
-    power: float = Field(..., ge=0, le=1, description="The power of the character, float from 0 to 1") 
+    power: float = Field(..., ge=0, le=1, description="The power of the character, float from 0 to 1")
     role: str = Field(..., description="The role of the character")
 
     def __str__(self):

--- a/tests/integration/llm/test_llm_response_parser_response_template.py
+++ b/tests/integration/llm/test_llm_response_parser_response_template.py
@@ -1,0 +1,106 @@
+import unittest
+
+import dotenv
+from typing import Type
+
+from pydantic import Field
+
+from council import OpenAILLM
+from council.llm.llm_function import LLMFunction, LLMFunctionResponse
+from council.llm.llm_response_parser import (
+    YAMLBlockResponseParser,
+    YAMLResponseParser,
+    JSONBlockResponseParser,
+    JSONResponseParser,
+)
+from council.utils import OsEnviron
+
+SYSTEM_PROMPT = """
+Generate an RPG character.
+
+# Response template
+{response_template}
+"""
+
+
+class Character:
+    name: str = Field(..., description="The name of the character")
+    power: float = Field(..., ge=0, le=1, description="The power of the character, float from 0 to 1") 
+    role: str = Field(..., description="The role of the character")
+
+    def __str__(self):
+        return f"Name: {self.name}, Power: {self.power}, Role: {self.role}"
+
+
+class YAMLBlockCharacter(YAMLBlockResponseParser, Character):
+    pass
+
+
+class YAMLCharacter(YAMLResponseParser, Character):
+    pass
+
+
+class JSONBlockCharacter(JSONBlockResponseParser, Character):
+    pass
+
+
+class JSONCharacter(JSONResponseParser, Character):
+    pass
+
+
+class TestLLMResponseParserResponseTemplate(unittest.TestCase):
+    """Requires an Azure LLM model deployed"""
+
+    def setUp(self) -> None:
+        dotenv.load_dotenv()
+        with OsEnviron("OPENAI_LLM_MODEL", "gpt-4o-mini"):
+            self.llm = OpenAILLM.from_env()
+
+    def _check_response(self, llm_function_response: LLMFunctionResponse, expected_response_type: Type):
+        response = llm_function_response.response
+        self.assertIsInstance(response, expected_response_type)
+        print("", response, sep="\n")
+
+        self.assertTrue(len(llm_function_response.consumptions) == 8)  # no self-correction
+
+    def test_yaml_block_response_parser(self):
+        llm_func = LLMFunction(
+            self.llm,
+            YAMLBlockCharacter.from_response,
+            system_message=SYSTEM_PROMPT.format(response_template=YAMLBlockCharacter.to_response_template()),
+        )
+        llm_function_response = llm_func.execute_with_llm_response(user_message="Create wise old wizard")
+
+        self._check_response(llm_function_response, YAMLBlockCharacter)
+
+    def test_yaml_response_parser(self):
+        llm_func = LLMFunction(
+            self.llm,
+            YAMLCharacter.from_response,
+            system_message=SYSTEM_PROMPT.format(response_template=YAMLCharacter.to_response_template()),
+        )
+        llm_function_response = llm_func.execute_with_llm_response(user_message="Create strong warrior")
+
+        self._check_response(llm_function_response, YAMLCharacter)
+
+    def test_json_block_response_parser(self):
+        llm_func = LLMFunction(
+            self.llm,
+            JSONBlockCharacter.from_response,
+            system_message=SYSTEM_PROMPT.format(response_template=JSONBlockCharacter.to_response_template()),
+        )
+        llm_function_response = llm_func.execute_with_llm_response(user_message="Create kind dwarf")
+
+        self._check_response(llm_function_response, JSONBlockCharacter)
+
+    def test_json_response_parser(self):
+        llm_func = LLMFunction(
+            self.llm,
+            JSONCharacter.from_response,
+            system_message=SYSTEM_PROMPT.format(response_template=JSONCharacter.to_response_template()),
+        )
+        llm_function_response = llm_func.execute_with_llm_response(
+            user_message="Create shadow thief", response_format={"type": "json_object"}
+        )
+
+        self._check_response(llm_function_response, JSONCharacter)

--- a/tests/unit/llm/test_llm_response_parser_response_template.py
+++ b/tests/unit/llm/test_llm_response_parser_response_template.py
@@ -1,0 +1,183 @@
+import unittest
+from council.llm.llm_response_parser import YAMLBlockResponseParser, YAMLResponseParser
+from pydantic import Field
+from typing import Literal, List
+
+
+class MissingDescriptionField(YAMLBlockResponseParser):
+    number: float = Field(..., description="Number from 1 to 10")
+    reasoning: str
+
+
+multiline_description = "Carefully\nreason about the number"
+
+
+class YAMLBlockResponse(YAMLBlockResponseParser):
+    reasoning: str = Field(..., description=multiline_description)
+    number: float = Field(..., ge=1, le=10, description="Number from 1 to 10")
+    abc: str = Field(..., description="Not multiline description")
+
+
+class YAMLResponse(YAMLResponseParser):
+    reasoning: str = Field(..., description=multiline_description)
+    number: float = Field(..., ge=1, le=10, description="Number from 1 to 10")
+    abc: str = Field(..., description="Not multiline description")
+
+
+class YAMLBlockResponseReordered(YAMLBlockResponseParser):
+    number: float = Field(..., ge=1, le=10, description="Number from 1 to 10")
+    abc: str = Field(..., description="Not multiline description")
+    reasoning: str = Field(..., description=multiline_description)
+
+
+class YAMLResponseReordered(YAMLResponseParser):
+    number: float = Field(..., ge=1, le=10, description="Number from 1 to 10")
+    abc: str = Field(..., description="Not multiline description")
+    reasoning: str = Field(..., description=multiline_description)
+
+
+class YAMLBlockResponseReorderedAgain(YAMLBlockResponseParser):
+    abc: str = Field(..., description="Not multiline description")
+    number: float = Field(..., ge=1, le=10, description="Number from 1 to 10")
+    reasoning: str = Field(..., description=multiline_description)
+
+
+class YAMLResponseReorderedAgain(YAMLResponseParser):
+    abc: str = Field(..., description="Not multiline description")
+    number: float = Field(..., ge=1, le=10, description="Number from 1 to 10")
+    reasoning: str = Field(..., description=multiline_description)
+
+
+class ComplexResponse(YAMLBlockResponseParser):
+    mode: Literal["mode_one", "mode_two"] = Field(..., description="Mode of operation, one of `mode_one` or `mode_two`")
+    pairs: List[YAMLBlockResponse] = Field(..., description="List of number and reasoning pairs")
+
+
+class TestYAMLBlockResponseParserResponseTemplate(unittest.TestCase):
+    def test_missing_description_field(self):
+        with self.assertRaises(ValueError) as e:
+            MissingDescriptionField.to_response_template()
+        self.assertEqual(str(e.exception), "Description is required for field `reasoning` in MissingDescriptionField")
+
+    def test_number_reasoning_pair_template(self):
+        template = YAMLBlockResponse.to_response_template(include_hints=False)
+        self.assertEqual(
+            template,
+            """```yaml
+reasoning: |
+  Carefully
+  reason about the number
+number: {{Number from 1 to 10}}
+abc: {{Not multiline description}}
+```""",
+        )
+
+    def test_number_reasoning_pair_reordered_template(self):
+        template = YAMLBlockResponseReordered.to_response_template(include_hints=False)
+        self.assertEqual(
+            template,
+            """```yaml
+number: {{Number from 1 to 10}}
+abc: {{Not multiline description}}
+reasoning: |
+  Carefully
+  reason about the number
+```""",
+        )
+
+    def test_number_reasoning_pair_reordered_again_template(self):
+        template = YAMLBlockResponseReorderedAgain.to_response_template(include_hints=False)
+        self.assertEqual(
+            template,
+            """```yaml
+abc: {{Not multiline description}}
+number: {{Number from 1 to 10}}
+reasoning: |
+  Carefully
+  reason about the number
+```""",
+        )
+
+    def test_complex_response_template(self):
+        template = ComplexResponse.to_response_template(include_hints=False)
+        # nested objects are not supported yet
+        self.assertEqual(
+            template,
+            """```yaml
+mode: {{Mode of operation, one of `mode_one` or `mode_two`}}
+pairs: {{List of number and reasoning pairs}}
+```""",
+        )
+
+    def test_with_hints(self):
+        template = YAMLBlockResponse.to_response_template(include_hints=True)
+        self.assertEqual(
+            template,
+            """- Provide your response in a single yaml code block.
+- Make sure you respect YAML syntax, particularly for lists and dictionaries.
+- All keys must be present in the response, even when their values are empty.
+- For empty values, include empty quotes ("") rather than leaving them blank.
+- Always wrap string values in double quotes (") to ensure proper parsing, except when using the YAML pipe operator (|) for multi-line strings.
+
+```yaml
+reasoning: |
+  Carefully
+  reason about the number
+number: {{Number from 1 to 10}}
+abc: {{Not multiline description}}
+```""",
+        )
+
+
+class TestYAMLResponseParserResponseTemplate(unittest.TestCase):
+    def test_number_reasoning_pair_template(self):
+        template = YAMLResponse.to_response_template(include_hints=False)
+        self.assertEqual(
+            template,
+            """reasoning: |
+  Carefully
+  reason about the number
+number: {{Number from 1 to 10}}
+abc: {{Not multiline description}}""",
+        )
+
+    def test_number_reasoning_pair_reordered_template(self):
+        template = YAMLResponseReordered.to_response_template(include_hints=False)
+        self.assertEqual(
+            template,
+            """number: {{Number from 1 to 10}}
+abc: {{Not multiline description}}
+reasoning: |
+  Carefully
+  reason about the number""",
+        )
+
+    def test_number_reasoning_pair_reordered_again_template(self):
+        template = YAMLResponseReorderedAgain.to_response_template(include_hints=False)
+        self.assertEqual(
+            template,
+            """abc: {{Not multiline description}}
+number: {{Number from 1 to 10}}
+reasoning: |
+  Carefully
+  reason about the number""",
+        )
+
+    def test_with_hints(self):
+        template = YAMLResponse.to_response_template(include_hints=True)
+        self.assertEqual(
+            template,
+            """- Provide your response as a parsable YAML.
+- Make sure you respect YAML syntax, particularly for lists and dictionaries.
+- All keys must be present in the response, even when their values are empty.
+- For empty values, include empty quotes ("") rather than leaving them blank.
+- Always wrap string values in double quotes (") to ensure proper parsing, except when using the YAML pipe operator (|) for multi-line strings.
+
+reasoning: |
+  Carefully
+  reason about the number
+number: {{Number from 1 to 10}}
+abc: {{Not multiline description}}
+
+Only respond with parsable YAML. Do not output anything else.""",
+        )

--- a/tests/unit/llm/test_llm_response_parser_response_template.py
+++ b/tests/unit/llm/test_llm_response_parser_response_template.py
@@ -67,8 +67,8 @@ class TestYAMLBlockResponseParserResponseTemplate(unittest.TestCase):
 reasoning: |
   Carefully
   reason about the number
-number: {{Number from 1 to 10}}
-abc: {{Not multiline description}}
+number: # Number from 1 to 10
+abc: # Not multiline description
 ```""",
         )
 
@@ -77,8 +77,8 @@ abc: {{Not multiline description}}
         self.assertEqual(
             template,
             """```yaml
-number: {{Number from 1 to 10}}
-abc: {{Not multiline description}}
+number: # Number from 1 to 10
+abc: # Not multiline description
 reasoning: |
   Carefully
   reason about the number
@@ -90,8 +90,8 @@ reasoning: |
         self.assertEqual(
             template,
             """```yaml
-abc: {{Not multiline description}}
-number: {{Number from 1 to 10}}
+abc: # Not multiline description
+number: # Number from 1 to 10
 reasoning: |
   Carefully
   reason about the number
@@ -104,8 +104,8 @@ reasoning: |
         self.assertEqual(
             template,
             """```yaml
-mode: {{Mode of operation, one of `mode_one` or `mode_two`}}
-pairs: {{List of number and reasoning pairs}}
+mode: # Mode of operation, one of `mode_one` or `mode_two`
+pairs: # List of number and reasoning pairs
 ```""",
         )
 
@@ -123,8 +123,8 @@ pairs: {{List of number and reasoning pairs}}
 reasoning: |
   Carefully
   reason about the number
-number: {{Number from 1 to 10}}
-abc: {{Not multiline description}}
+number: # Number from 1 to 10
+abc: # Not multiline description
 ```""",
         )
 
@@ -137,16 +137,16 @@ class TestYAMLResponseParserResponseTemplate(unittest.TestCase):
             """reasoning: |
   Carefully
   reason about the number
-number: {{Number from 1 to 10}}
-abc: {{Not multiline description}}""",
+number: # Number from 1 to 10
+abc: # Not multiline description""",
         )
 
     def test_number_reasoning_pair_reordered_template(self):
         template = YAMLResponseReordered.to_response_template(include_hints=False)
         self.assertEqual(
             template,
-            """number: {{Number from 1 to 10}}
-abc: {{Not multiline description}}
+            """number: # Number from 1 to 10
+abc: # Not multiline description
 reasoning: |
   Carefully
   reason about the number""",
@@ -156,8 +156,8 @@ reasoning: |
         template = YAMLResponseReorderedAgain.to_response_template(include_hints=False)
         self.assertEqual(
             template,
-            """abc: {{Not multiline description}}
-number: {{Number from 1 to 10}}
+            """abc: # Not multiline description
+number: # Number from 1 to 10
 reasoning: |
   Carefully
   reason about the number""",
@@ -176,8 +176,8 @@ reasoning: |
 reasoning: |
   Carefully
   reason about the number
-number: {{Number from 1 to 10}}
-abc: {{Not multiline description}}
+number: # Number from 1 to 10
+abc: # Not multiline description
 
 Only respond with parsable YAML. Do not output anything else.""",
         )

--- a/tests/unit/llm/test_llm_response_parser_response_template.py
+++ b/tests/unit/llm/test_llm_response_parser_response_template.py
@@ -100,7 +100,7 @@ class TestYAMLBlockResponseParserResponseTemplate(unittest.TestCase):
             MissingDescriptionField.to_response_template()
         self.assertEqual(str(e.exception), "Description is required for field `reasoning` in MissingDescriptionField")
 
-    def test_number_reasoning_pair_template(self):
+    def test_template(self):
         template = YAMLBlockResponse.to_response_template(include_hints=False)
         self.assertEqual(
             template,
@@ -113,7 +113,7 @@ abc: # Not multiline description
 ```""",
         )
 
-    def test_number_reasoning_pair_reordered_template(self):
+    def test_reordered_template(self):
         template = YAMLBlockResponseReordered.to_response_template(include_hints=False)
         self.assertEqual(
             template,
@@ -126,7 +126,7 @@ reasoning: |
 ```""",
         )
 
-    def test_number_reasoning_pair_reordered_again_template(self):
+    def test_reordered_again_template(self):
         template = YAMLBlockResponseReorderedAgain.to_response_template(include_hints=False)
         self.assertEqual(
             template,
@@ -154,7 +154,7 @@ pairs: # List of number and reasoning pairs
         template = YAMLBlockResponse.to_response_template(include_hints=True)
         self.assertEqual(
             template,
-            """- Provide your response in a single yaml code block.
+            """- Provide your response in a single YAML code block.
 - Make sure you respect YAML syntax, particularly for lists and dictionaries.
 - All keys must be present in the response, even when their values are empty.
 - For empty values, include empty quotes ("") rather than leaving them blank.
@@ -171,7 +171,7 @@ abc: # Not multiline description
 
 
 class TestYAMLResponseParserResponseTemplate(unittest.TestCase):
-    def test_number_reasoning_pair_template(self):
+    def test_template(self):
         template = YAMLResponse.to_response_template(include_hints=False)
         self.assertEqual(
             template,
@@ -182,7 +182,7 @@ number: # Number from 1 to 10
 abc: # Not multiline description""",
         )
 
-    def test_number_reasoning_pair_reordered_template(self):
+    def test_reordered_template(self):
         template = YAMLResponseReordered.to_response_template(include_hints=False)
         self.assertEqual(
             template,
@@ -193,7 +193,7 @@ reasoning: |
   reason about the number""",
         )
 
-    def test_number_reasoning_pair_reordered_again_template(self):
+    def test_reordered_again_template(self):
         template = YAMLResponseReorderedAgain.to_response_template(include_hints=False)
         self.assertEqual(
             template,
@@ -225,7 +225,7 @@ Only respond with parsable YAML. Do not output anything else. Do not wrap your r
 
 
 class TestJSONBlockResponseParserResponseTemplate(unittest.TestCase):
-    def test_number_reasoning_pair_template(self):
+    def test_template(self):
         template = JSONBlockResponse.to_response_template(include_hints=False)
         self.assertEqual(
             template,
@@ -238,7 +238,7 @@ class TestJSONBlockResponseParserResponseTemplate(unittest.TestCase):
 ```""",
         )
 
-    def test_number_reasoning_pair_reordered_template(self):
+    def test_reordered_template(self):
         template = JSONBlockResponseReordered.to_response_template(include_hints=False)
         self.assertEqual(
             template,
@@ -251,7 +251,7 @@ class TestJSONBlockResponseParserResponseTemplate(unittest.TestCase):
 ```""",
         )
 
-    def test_number_reasoning_pair_reordered_again_template(self):
+    def test_reordered_again_template(self):
         template = JSONBlockResponseReorderedAgain.to_response_template(include_hints=False)
         self.assertEqual(
             template,
@@ -268,7 +268,7 @@ class TestJSONBlockResponseParserResponseTemplate(unittest.TestCase):
         template = JSONBlockResponse.to_response_template(include_hints=True)
         self.assertEqual(
             template,
-            """- Provide your response in a single json code block.
+            """- Provide your response in a single JSON code block.
 - Make sure you respect JSON syntax, particularly for lists and dictionaries.
 - All keys must be present in the response, even when their values are empty.
 - For empty values, include empty quotes ("") rather than leaving them blank.
@@ -284,7 +284,7 @@ class TestJSONBlockResponseParserResponseTemplate(unittest.TestCase):
 
 
 class TestJSONResponseParserResponseTemplate(unittest.TestCase):
-    def test_number_reasoning_pair_template(self):
+    def test_template(self):
         template = JSONResponse.to_response_template(include_hints=False)
         self.assertEqual(
             template,
@@ -295,7 +295,7 @@ class TestJSONResponseParserResponseTemplate(unittest.TestCase):
 }""",
         )
 
-    def test_number_reasoning_pair_reordered_template(self):
+    def test_reordered_template(self):
         template = JSONResponseReordered.to_response_template(include_hints=False)
         self.assertEqual(
             template,
@@ -306,7 +306,7 @@ class TestJSONResponseParserResponseTemplate(unittest.TestCase):
 }""",
         )
 
-    def test_number_reasoning_pair_reordered_again_template(self):
+    def test_reordered_again_template(self):
         template = JSONResponseReorderedAgain.to_response_template(include_hints=False)
         self.assertEqual(
             template,


### PR DESCRIPTION
- Implement the ability to format response template prompts automatically based on object schema for `YAMLBlockResponseParser`, `YAMLResponseParser`, `JSONBlockResponseParser` and `JSONResponseParser`
- No support for nested objects
- Add common hints for YAML/JSON formatting for LLM