### PR TITLE
Feature update Groq costs

### DIFF
--- a/council/llm/providers/groq/data/groq-costs.yaml
+++ b/council/llm/providers/groq/data/groq-costs.yaml
@@ -10,24 +10,42 @@ spec:
     description: |
       Costs for Groq LLMs
     models:
+      # Production Models
       gemma2-9b-it:
         input: 0.20
         output: 0.20
-      gemma-7b-it:
+      gemma-7b-it: # will be deprecated December 18, 2024
         input: 0.07
         output: 0.07
+      llama-3.3-70b-versatile:
+        input: 0.59
+        output: 0.79
+      llama-3.1-70b-versatile: # will be deprecated December 20, 2024
+        input: 0.59
+        output: 0.79
+      llama-guard-3-8b:
+        input: 0.20
+        output: 0.20
+      llama3-70b-8192:
+        input: 0.59
+        output: 0.79
+      llama-3.1-8b-instant:
+        input: 0.05
+        output: 0.08
+      mixtral-8x7b-32768:
+        input: 0.24
+        output: 0.24
+
+      # Preview Models
       llama3-groq-70b-8192-tool-use-preview:
         input: 0.89
         output: 0.89
       llama3-groq-8b-8192-tool-use-preview:
         input: 0.19
         output: 0.19
-      llama-3.1-70b-versatile:
+      llama-3.3-70b-specdec:
         input: 0.59
-        output: 0.79
-      llama-3.1-8b-instant:
-        input: 0.05
-        output: 0.08
+        output: 0.99
       llama-3.2-1b-preview:
         input: 0.04
         output: 0.04
@@ -40,15 +58,3 @@ spec:
       llama-3.2-90b-vision-preview:
         input: 0.90
         output: 0.90
-      llama-guard-3-8b:
-        input: 0.20
-        output: 0.20
-      llama3-70b-8192:
-        input: 0.59
-        output: 0.79
-      llama3-8b-8192:
-        input: 0.05
-        output: 0.08
-      mixtral-8x7b-32768:
-        input: 0.24
-        output: 0.24

--- a/council/llm/providers/groq/data/groq-costs.yaml
+++ b/council/llm/providers/groq/data/groq-costs.yaml
@@ -14,9 +14,6 @@ spec:
       gemma2-9b-it:
         input: 0.20
         output: 0.20
-      gemma-7b-it: # will be deprecated December 18, 2024
-        input: 0.07
-        output: 0.07
       llama-3.3-70b-versatile:
         input: 0.59
         output: 0.79

--- a/council/llm/providers/groq/data/groq-costs.yaml
+++ b/council/llm/providers/groq/data/groq-costs.yaml
@@ -20,9 +20,6 @@ spec:
       llama-3.3-70b-versatile:
         input: 0.59
         output: 0.79
-      llama-3.1-70b-versatile: # will be deprecated December 20, 2024
-        input: 0.59
-        output: 0.79
       llama-guard-3-8b:
         input: 0.20
         output: 0.20

--- a/tests/integration/llm/test_groq_llm.py
+++ b/tests/integration/llm/test_groq_llm.py
@@ -10,14 +10,14 @@ from council.utils import OsEnviron
 
 class TestGroqLLM(unittest.TestCase):
     @staticmethod
-    def get_gemma_7b():
+    def get_gemma():
         dotenv.load_dotenv()
-        with OsEnviron("GROQ_LLM_MODEL", "gemma-7b-it"):
+        with OsEnviron("GROQ_LLM_MODEL", "gemma2-9b-it"):
             return GroqLLM.from_env()
 
     def test_message(self):
         messages = [LLMMessage.user_message("what is the capital of France?")]
-        llm = self.get_gemma_7b()
+        llm = self.get_gemma()
 
         result = llm.post_chat_request(LLMContext.empty(), messages)
         assert "Paris" in result.choices[0]
@@ -29,15 +29,15 @@ class TestGroqLLM(unittest.TestCase):
 
     def test_consumptions(self):
         messages = [LLMMessage.user_message("Hello how are you?")]
-        llm = self.get_gemma_7b()
+        llm = self.get_gemma()
         result = llm.post_chat_request(LLMContext.empty(), messages)
 
         assert len(result.consumptions) == 12  # call, duration, 3 token kinds, 3 cost kinds and 4 groq duration
         for consumption in result.consumptions:
-            assert consumption.kind.startswith("gemma-7b-it")
+            assert consumption.kind.startswith("gemma2-9b-it")
 
     def test_max_tokens_param(self):
-        llm = self.get_gemma_7b()
+        llm = self.get_gemma()
         llm.configuration.temperature.set(0.8)
         llm.configuration.max_tokens.set(7)
 
@@ -47,7 +47,7 @@ class TestGroqLLM(unittest.TestCase):
 
     def test_json_mode(self):
         messages = [LLMMessage.user_message("Output a JSON object with the data about RPG character.")]
-        llm = self.get_gemma_7b()
+        llm = self.get_gemma()
         result = llm.post_chat_request(LLMContext.empty(), messages, response_format={"type": "json_object"})
 
         data = json.loads(result.first_choice)

--- a/tests/unit/llm/test_llm_consumption_calculators.py
+++ b/tests/unit/llm/test_llm_consumption_calculators.py
@@ -345,18 +345,13 @@ class TestGroqConsumptionCalculator(unittest.TestCase):
         self.assertEqual(prompt_cost, 0.20)  # $0.20 per 1M tokens * 1M
         self.assertEqual(completion_cost, 0.10)  # $0.20 per 1M tokens * 0.5M
 
-        cost_card = GroqConsumptionCalculator("gemma-7b-it").find_model_costs()
-        prompt_cost, completion_cost = cost_card.get_costs(1_000_000, 500_000)
-        self.assertEqual(prompt_cost, 0.07)  # $0.07 per 1M tokens * 1M
-        self.assertEqual(completion_cost, 0.035)  # $0.07 per 1M tokens * 0.5M
-
     def test_llama3_cost_calculations(self):
         cost_card = GroqConsumptionCalculator("llama3-70b-8192").find_model_costs()
         prompt_cost, completion_cost = cost_card.get_costs(1_000_000, 500_000)
         self.assertEqual(prompt_cost, 0.59)  # $0.59 per 1M tokens * 1M
         self.assertEqual(completion_cost, 0.395)  # $0.79 per 1M tokens * 0.5M
 
-        cost_card = GroqConsumptionCalculator("llama3-8b-8192").find_model_costs()
+        cost_card = GroqConsumptionCalculator("llama-3.1-8b-instant").find_model_costs()
         prompt_cost, completion_cost = cost_card.get_costs(1_000_000, 500_000)
         self.assertEqual(prompt_cost, 0.05)  # $0.05 per 1M tokens * 1M
         self.assertEqual(completion_cost, 0.04)  # $0.08 per 1M tokens * 0.5M
@@ -372,16 +367,16 @@ class TestGroqConsumptionCalculator(unittest.TestCase):
         self.assertEqual(prompt_cost, 0.19)  # $0.19 per 1M tokens * 1M
         self.assertEqual(completion_cost, 0.095)  # $0.19 per 1M tokens * 0.5M
 
-    def test_llama_31_cost_calculations(self):
-        cost_card = GroqConsumptionCalculator("llama-3.1-70b-versatile").find_model_costs()
+    def test_llama_33_cost_calculations(self):
+        cost_card = GroqConsumptionCalculator("llama-3.3-70b-versatile").find_model_costs()
         prompt_cost, completion_cost = cost_card.get_costs(1_000_000, 500_000)
         self.assertEqual(prompt_cost, 0.59)  # $0.59 per 1M tokens * 1M
         self.assertEqual(completion_cost, 0.395)  # $0.79 per 1M tokens * 0.5M
 
-        cost_card = GroqConsumptionCalculator("llama-3.1-8b-instant").find_model_costs()
+        cost_card = GroqConsumptionCalculator("llama-3.3-70b-specdec").find_model_costs()
         prompt_cost, completion_cost = cost_card.get_costs(1_000_000, 500_000)
-        self.assertEqual(prompt_cost, 0.05)  # $0.05 per 1M tokens * 1M
-        self.assertEqual(completion_cost, 0.04)  # $0.08 per 1M tokens * 0.5M
+        self.assertEqual(prompt_cost, 0.59)  # $0.59 per 1M tokens * 1M
+        self.assertEqual(completion_cost, 0.495)  # $0.99 per 1M tokens * 0.5M
 
     def test_llama_32_cost_calculations(self):
         models = {


### PR DESCRIPTION
- Add costs for `llama-3.3`
- Delete deprecated models such as `gemma-7b-it`, `llama-3.1-70b-versatile`, `llama-3.1-8b-instant`