### PR TITLE
Feature support nested objects for parsers

### DIFF
--- a/council/llm/llm_function/llm_response_parser.py
+++ b/council/llm/llm_function/llm_response_parser.py
@@ -229,12 +229,12 @@ class YAMLResponseParserBase(BaseModelResponseParser, abc.ABC):
 
             is_multiline_description = "\n" in description
 
-            # nested BaseModel object
+            # nested BaseModel
             if cls._is_of_type(field_type, YAMLResponseParserBase):
                 template_parts.append(f"{indent}{field_name}: # {description}")
                 nested_template = field_type._to_response_template(indent_level + 1)
                 template_parts.append(nested_template)
-            # list of BaseModel objects
+            # list of BaseModels
             elif cls._is_list_of_type(field_type, YAMLResponseParserBase):
                 template_parts.append(f"{indent}{field_name}: # {description}")
                 template_parts.append(f"{indent}- # Each element being:")
@@ -330,11 +330,11 @@ class JSONResponseParserBase(BaseModelResponseParser, abc.ABC):
             if field_type is None:
                 raise ValueError(f"Type annotation is required for field `{field_name}` in {cls.__name__}")
 
-            # nested BaseModel object
+            # nested BaseModel
             if cls._is_of_type(field_type, JSONResponseParserBase):
                 nested_template = json.loads(field_type._to_response_template())
                 template_dict[field_name] = nested_template
-            # list of BaseModel objects
+            # list of BaseModels
             elif cls._is_list_of_type(field_type, JSONResponseParserBase):
                 nested_template = json.loads(field_type.__args__[0]._to_response_template())
                 template_dict[field_name] = [nested_template]

--- a/docs/source/reference/llm.md
+++ b/docs/source/reference/llm.md
@@ -69,7 +69,7 @@ for consumption in result.consumptions:
 
 #### Anthropic Prompt Caching Support
 
-For information about enabling Anthropic prompt caching, refer to {class}`~council.llm.llm_message.LLMCacheControlData`.
+For information about enabling Anthropic prompt caching, refer to {class}`~council.llm.LLMCacheControlData`.
 
 ### LLM Functions
 
@@ -82,11 +82,11 @@ LLM Functions provide structured ways to interact with LLMs including built-in r
 
 Response parsers help automate the parsing of common response formats to use LLMFunctions conveniently:
 
-- {class}`~council.llm.llm_response_parser.EchoResponseParser` for raw {class}`~council.llm.LLMResponse`
-- {class}`~council.llm.llm_response_parser.StringResponseParser` for plain text
-- {class}`~council.llm.llm_response_parser.CodeBlocksResponseParser` for code blocks
-- {class}`~council.llm.llm_response_parser.YAMLBlockResponseParser` and {class}`~council.llm.llm_response_parser.YAMLResponseParser` for YAML
-- {class}`~council.llm.llm_response_parser.JSONBlockResponseParser` and {class}`~council.llm.llm_response_parser.JSONResponseParser` for JSON
+- {class}`~council.llm.EchoResponseParser` for raw {class}`~council.llm.LLMResponse`
+- {class}`~council.llm.StringResponseParser` for plain text
+- {class}`~council.llm.CodeBlocksResponseParser` for code blocks
+- {class}`~council.llm.YAMLBlockResponseParser` and {class}`~council.llm.YAMLResponseParser` for YAML
+- {class}`~council.llm.JSONBlockResponseParser` and {class}`~council.llm.JSONResponseParser` for JSON
 
 ### LLM Middleware
 

--- a/tests/unit/llm/test_llm_response_parser_response_template.py
+++ b/tests/unit/llm/test_llm_response_parser_response_template.py
@@ -479,7 +479,7 @@ class TestJSONBlockResponseParserResponseTemplate(unittest.TestCase):
     "mode": "Mode of operation, one of `mode_one` or `mode_two`",
     "pairs": [
       {
-        "reasoning": "Carefully\nreason about the number",
+        "reasoning": "Carefully\\nreason about the number",
         "number": "Number from 1 to 10",
         "abc": "Not multiline description"
       }
@@ -552,7 +552,7 @@ Only respond with parsable JSON. Do not output anything else.""",
     "mode": "Mode of operation, one of `mode_one` or `mode_two`",
     "pairs": [
       {
-        "reasoning": "Carefully\nreason about the number",
+        "reasoning": "Carefully\\nreason about the number",
         "number": "Number from 1 to 10",
         "abc": "Not multiline description"
       }

--- a/tests/unit/llm/test_llm_response_parser_response_template.py
+++ b/tests/unit/llm/test_llm_response_parser_response_template.py
@@ -107,6 +107,11 @@ class ComplexResponse(YAMLBlockResponseParser):
     pairs: List[YAMLBlockResponse] = Field(..., description="List of number and reasoning pairs")
 
 
+class NestedResponse(YAMLBlockResponseParser):
+    score: float = Field(..., description="Float score")
+    response: ComplexResponse = Field(..., description="Complex response")
+
+
 class TestCodeBlocksResponseParserTemplate(unittest.TestCase):
     def test_missing_description_field(self):
         with self.assertRaises(ValueError) as e:
@@ -275,17 +280,6 @@ reasoning: |
 ```""",
         )
 
-    def test_complex_response_template(self):
-        template = ComplexResponse.to_response_template(include_hints=False)
-        # nested objects are not supported yet
-        self.assertEqual(
-            template,
-            """```yaml
-mode: # Mode of operation, one of `mode_one` or `mode_two`
-pairs: # List of number and reasoning pairs
-```""",
-        )
-
     def test_with_hints(self):
         template = YAMLBlockResponse.to_response_template(include_hints=True)
         self.assertEqual(
@@ -302,6 +296,24 @@ reasoning: |
   reason about the number
 number: # Number from 1 to 10
 abc: # Not multiline description
+```""",
+        )
+
+    def test_nested_response_template(self):
+        template = NestedResponse.to_response_template(include_hints=False)
+        self.assertEqual(
+            template,
+            """```yaml
+score: # Float score
+response: # Complex response
+  mode: # Mode of operation, one of `mode_one` or `mode_two`
+  pairs: # List of number and reasoning pairs
+  - # Each element being:
+    reasoning: |
+      Carefully
+      reason about the number
+    number: # Number from 1 to 10
+    abc: # Not multiline description
 ```""",
         )
 

--- a/tests/unit/llm/test_llm_response_parser_response_template.py
+++ b/tests/unit/llm/test_llm_response_parser_response_template.py
@@ -107,6 +107,11 @@ class YAMLComplexResponse(YAMLBlockResponseParser):
     pairs: List[YAMLBlockResponse] = Field(..., description="List of number and reasoning pairs")
 
 
+class JSONComplexResponse(JSONBlockResponseParser):
+    mode: Literal["mode_one", "mode_two"] = Field(..., description="Mode of operation, one of `mode_one` or `mode_two`")
+    pairs: List[JSONBlockResponse] = Field(..., description="List of number and reasoning pairs")
+
+
 class YAMLBlockNestedResponse(YAMLBlockResponseParser):
     score: float = Field(..., description="Float score")
     response: YAMLComplexResponse = Field(..., description="Complex response")
@@ -115,6 +120,16 @@ class YAMLBlockNestedResponse(YAMLBlockResponseParser):
 class YAMLNestedResponse(YAMLResponseParser):
     score: float = Field(..., description="Float score")
     response: YAMLComplexResponse = Field(..., description="Complex response")
+
+
+class JSONBlockNestedResponse(JSONBlockResponseParser):
+    score: float = Field(..., description="Float score")
+    response: JSONComplexResponse = Field(..., description="Complex response")
+
+
+class JSONNestedResponse(JSONResponseParser):
+    score: float = Field(..., description="Float score")
+    response: JSONComplexResponse = Field(..., description="Complex response")
 
 
 class TestCodeBlocksResponseParserTemplate(unittest.TestCase):
@@ -451,6 +466,27 @@ class TestJSONBlockResponseParserResponseTemplate(unittest.TestCase):
 ```""",
         )
 
+    def test_nested_response_template(self):
+        template = JSONBlockNestedResponse.to_response_template(include_hints=False)
+        self.assertEqual(
+            template,
+            """```json
+{
+  "score": "Float score",
+  "response": {
+    "mode": "Mode of operation, one of `mode_one` or `mode_two`",
+    "pairs": [
+      {
+        "reasoning": "Carefully\nreason about the number",
+        "number": "Number from 1 to 10",
+        "abc": "Not multiline description"
+      }
+    ]
+  }
+}
+```""",
+        )
+
 
 class TestJSONResponseParserResponseTemplate(unittest.TestCase):
     def test_template(self):
@@ -502,4 +538,23 @@ class TestJSONResponseParserResponseTemplate(unittest.TestCase):
 }
 
 Only respond with parsable JSON. Do not output anything else.""",
+        )
+
+    def test_nested_response_template(self):
+        template = JSONNestedResponse.to_response_template(include_hints=False)
+        self.assertEqual(
+            template,
+            """{
+  "score": "Float score",
+  "response": {
+    "mode": "Mode of operation, one of `mode_one` or `mode_two`",
+    "pairs": [
+      {
+        "reasoning": "Carefully\nreason about the number",
+        "number": "Number from 1 to 10",
+        "abc": "Not multiline description"
+      }
+    ]
+  }
+}""",
         )

--- a/tests/unit/llm/test_llm_response_parser_response_template.py
+++ b/tests/unit/llm/test_llm_response_parser_response_template.py
@@ -102,14 +102,19 @@ class JSONResponseReorderedAgain(JSONResponseParser, BaseResponseReorderedAgain)
     pass
 
 
-class ComplexResponse(YAMLBlockResponseParser):
+class YAMLComplexResponse(YAMLBlockResponseParser):
     mode: Literal["mode_one", "mode_two"] = Field(..., description="Mode of operation, one of `mode_one` or `mode_two`")
     pairs: List[YAMLBlockResponse] = Field(..., description="List of number and reasoning pairs")
 
 
-class NestedResponse(YAMLBlockResponseParser):
+class YAMLBlockNestedResponse(YAMLBlockResponseParser):
     score: float = Field(..., description="Float score")
-    response: ComplexResponse = Field(..., description="Complex response")
+    response: YAMLComplexResponse = Field(..., description="Complex response")
+
+
+class YAMLNestedResponse(YAMLResponseParser):
+    score: float = Field(..., description="Float score")
+    response: YAMLComplexResponse = Field(..., description="Complex response")
 
 
 class TestCodeBlocksResponseParserTemplate(unittest.TestCase):
@@ -300,7 +305,7 @@ abc: # Not multiline description
         )
 
     def test_nested_response_template(self):
-        template = NestedResponse.to_response_template(include_hints=False)
+        template = YAMLBlockNestedResponse.to_response_template(include_hints=False)
         self.assertEqual(
             template,
             """```yaml
@@ -369,6 +374,22 @@ number: # Number from 1 to 10
 abc: # Not multiline description
 
 Only respond with parsable YAML. Do not output anything else. Do not wrap your response in ```yaml```.""",
+        )
+
+    def test_nested_response_template(self):
+        template = YAMLNestedResponse.to_response_template(include_hints=False)
+        self.assertEqual(
+            template,
+            """score: # Float score
+response: # Complex response
+  mode: # Mode of operation, one of `mode_one` or `mode_two`
+  pairs: # List of number and reasoning pairs
+  - # Each element being:
+    reasoning: |
+      Carefully
+      reason about the number
+    number: # Number from 1 to 10
+    abc: # Not multiline description""",
         )
 
 


### PR DESCRIPTION
- Support nested objects and list of objects for YAML and JSON parsers
- Only support primitives for `CodeBlocksResponseParser`
