### PR TITLE
Fix LLMTimestampFileLoggingMiddleware

### DIFF
--- a/council/llm/llm_function/llm_middleware.py
+++ b/council/llm/llm_function/llm_middleware.py
@@ -270,20 +270,21 @@ class LLMTimestampFileLoggingMiddleware(LLMLoggingMiddlewareBase):
 
     def __init__(
         self,
-        prefix: str,
-        path: str = ".",
         strategy: LLMLoggingStrategy = LLMLoggingStrategy.Verbose,
+        *,
+        path: str = ".",
+        filename_prefix: Optional[str] = None,
         component_name: Optional[str] = None,
     ) -> None:
         super().__init__(strategy, component_name)
-        self.prefix = prefix
+        self.prefix = f"{filename_prefix}_" if filename_prefix is not None else ""
         self.path = path
         self._lock = Lock()
         self._current_filename: Optional[str] = None
 
     def __call__(self, llm: LLMBase, execute: ExecuteLLMRequest, request: LLMRequest) -> LLMResponse:
         timestamp = time.strftime("%Y-%m-%d_%H-%M-%S")
-        self._current_filename = os.path.join(self.path, f"{self.prefix}_{timestamp}.log")
+        self._current_filename = os.path.join(self.path, f"{self.prefix}{timestamp}.log")
 
         try:
             return super().__call__(llm, execute, request)

--- a/council/llm/llm_function/llm_middleware.py
+++ b/council/llm/llm_function/llm_middleware.py
@@ -285,11 +285,9 @@ class LLMTimestampFileLoggingMiddleware(LLMLoggingMiddlewareBase):
     def __call__(self, llm: LLMBase, execute: ExecuteLLMRequest, request: LLMRequest) -> LLMResponse:
         timestamp = time.strftime("%Y-%m-%d_%H-%M-%S")
         self._current_filename = os.path.join(self.path, f"{self.prefix}{timestamp}.log")
-
-        try:
-            return super().__call__(llm, execute, request)
-        finally:
-            self._current_filename = None  # clear the current filename after processing is complete
+        response = super().__call__(llm, execute, request)
+        self._current_filename = None
+        return response
 
     def _log(self, content: str) -> None:
         """Write content to the current log file"""

--- a/council/llm/llm_function/llm_middleware.py
+++ b/council/llm/llm_function/llm_middleware.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import time
 from collections import OrderedDict
 from enum import Enum
@@ -240,7 +241,7 @@ class LLMLoggingMiddleware(LLMLoggingMiddlewareBase):
 
     def _log(self, content: str) -> None:
         if self.context_logger is None:
-            raise RuntimeError("Calling LLMLoggingMiddleware._log() outside of __call__()")
+            raise RuntimeError("Context logger not set - calling LLMLoggingMiddleware._log() outside of __call__()")
 
         self.context_logger.info(content)
 
@@ -270,19 +271,33 @@ class LLMTimestampFileLoggingMiddleware(LLMLoggingMiddlewareBase):
     def __init__(
         self,
         prefix: str,
+        path: str = ".",
         strategy: LLMLoggingStrategy = LLMLoggingStrategy.Verbose,
         component_name: Optional[str] = None,
     ) -> None:
         super().__init__(strategy, component_name)
         self.prefix = prefix
+        self.path = path
         self._lock = Lock()
+        self._current_filename: Optional[str] = None
+
+    def __call__(self, llm: LLMBase, execute: ExecuteLLMRequest, request: LLMRequest) -> LLMResponse:
+        timestamp = time.strftime("%Y-%m-%d_%H-%M-%S")
+        self._current_filename = os.path.join(self.path, f"{self.prefix}_{timestamp}.log")
+
+        try:
+            return super().__call__(llm, execute, request)
+        finally:
+            self._current_filename = None  # clear the current filename after processing is complete
 
     def _log(self, content: str) -> None:
-        """Write content to a new log file with timestamp"""
-        timestamp = time.strftime("%Y-%m-%d_%H-%M-%S")
-        filename = f"{self.prefix}_{timestamp}.log"
+        """Write content to the current log file"""
+        if self._current_filename is None:
+            raise RuntimeError(
+                "Current log filename not set - calling LLMTimestampFileLoggingMiddleware._log() outside of __call__()"
+            )
 
-        self.append_to_file(self._lock, file_path=filename, content=content)
+        self.append_to_file(self._lock, file_path=self._current_filename, content=content)
 
 
 class LLMRetryMiddleware:

--- a/docs/source/reference/llm.md
+++ b/docs/source/reference/llm.md
@@ -95,7 +95,9 @@ Middleware components allow you to enhance LLM interactions by modifying request
 Core middlewares:
 
 - Caching: {class}`~council.llm.LLMCachingMiddleware`
-- Logging: {class}`~council.llm.LLMLoggingMiddleware` and {class}`~council.llm.LLMFileLoggingMiddleware`
+- Logging: 
+  - Context logger: {class}`~council.llm.LLMLoggingMiddleware`
+  - Files: {class}`~council.llm.LLMFileLoggingMiddleware` and {class}`~council.llm.LLMTimestampFileLoggingMiddleware`
 
 Middleware management:
 

--- a/tests/unit/llm/test_llm_middleware.py
+++ b/tests/unit/llm/test_llm_middleware.py
@@ -82,7 +82,7 @@ class TestLlmTimestampFileLoggingMiddleware(unittest.TestCase):
         request = LLMRequest.default(messages)
 
         chain = LLMMiddlewareChain(self._llm)
-        chain.add_middleware(LLMTimestampFileLoggingMiddleware(prefix=self._log_prefix, path=self._temp_dir))
+        chain.add_middleware(LLMTimestampFileLoggingMiddleware(path=self._temp_dir, filename_prefix=self._log_prefix))
 
         chain.execute(request)
         time.sleep(1)  # ensure different timestamps
@@ -104,7 +104,7 @@ class TestLlmTimestampFileLoggingMiddleware(unittest.TestCase):
         request = LLMRequest.default(messages)
 
         chain = LLMMiddlewareChain(self._llm_with_delay)
-        chain.add_middleware(LLMTimestampFileLoggingMiddleware(prefix=self._log_prefix, path=self._temp_dir))
+        chain.add_middleware(LLMTimestampFileLoggingMiddleware(path=self._temp_dir, filename_prefix=self._log_prefix))
 
         chain.execute(request)
 

--- a/tests/unit/llm/test_llm_middleware.py
+++ b/tests/unit/llm/test_llm_middleware.py
@@ -69,7 +69,10 @@ class TestLlmMiddleware(unittest.TestCase):
 class TestLlmTimestampFileLoggingMiddleware(unittest.TestCase):
     def setUp(self) -> None:
         self._llm = MockLLM.from_response("USD")
+        self._llm_with_delay = MockLLM.from_response("USD", delay=1.0)
         self._temp_dir = tempfile.mkdtemp()
+
+        self._log_prefix = "test_llm"
 
     def tearDown(self) -> None:
         shutil.rmtree(self._temp_dir)
@@ -78,17 +81,35 @@ class TestLlmTimestampFileLoggingMiddleware(unittest.TestCase):
         messages = [LLMMessage.user_message("Give me an example of a currency")]
         request = LLMRequest.default(messages)
 
-        log_prefix = os.path.join(self._temp_dir, "test_llm")
         chain = LLMMiddlewareChain(self._llm)
-        chain.add_middleware(LLMTimestampFileLoggingMiddleware(prefix=log_prefix))
+        chain.add_middleware(LLMTimestampFileLoggingMiddleware(prefix=self._log_prefix, path=self._temp_dir))
 
         chain.execute(request)
         time.sleep(1)  # ensure different timestamps
 
         chain.execute(request)
 
-        log_files = glob.glob(os.path.join(self._temp_dir, "test_llm_*.log"))
+        log_files = glob.glob(os.path.join(self._temp_dir, f"{self._log_prefix}_*.log"))
         self.assertEqual(2, len(log_files))
+
+        for log_file in log_files:
+            with open(log_file, "r", encoding="utf-8") as f:
+                content = f.read()
+                self.assertIn("LLM input", content)
+                self.assertIn("LLM output", content)
+                self.assertIn("USD", content)
+
+    def test_with_delay(self):
+        messages = [LLMMessage.user_message("Give me an example of a currency")]
+        request = LLMRequest.default(messages)
+
+        chain = LLMMiddlewareChain(self._llm_with_delay)
+        chain.add_middleware(LLMTimestampFileLoggingMiddleware(prefix=self._log_prefix, path=self._temp_dir))
+
+        chain.execute(request)
+
+        log_files = glob.glob(os.path.join(self._temp_dir, f"{self._log_prefix}_*.log"))
+        self.assertEqual(1, len(log_files))
 
         for log_file in log_files:
             with open(log_file, "r", encoding="utf-8") as f:


### PR DESCRIPTION
- Fix `LLMTimestampFileLoggingMiddleware` to create a single file for request-response pair; add path into parameters
- Add `delay` parameter to `MockLLM`